### PR TITLE
Cogent 2.1

### DIFF
--- a/cogent/COGENT/DocGent.hs
+++ b/cogent/COGENT/DocGent.hs
@@ -131,9 +131,14 @@ prettyType (LocType p (TCon t ts Writable)) x | not $ null ts = let rest = foldM
                                                                     rows = map row ts
                                                                     t' = withLinking ?knowns t
                                                                 in [shamlet|<table><tr><td class='fg-Vivid-Blue BoldIntensity'>#{t'}</td><td></td><td></td></tr>#{rows}<tr><td></td><td>#{rest}</td></tr>|]
-prettyType (LocType _ (TVariant ts)) x     = let rest = foldMap id x
+prettyType (LocType p (TVariant ts)) x | any snd $ (F.toList ts)
+                                       , ls <- map fst $ filter (snd . snd) (M.toList ts)
+                                       , ts' <- fmap (fmap (const False)) ts
+                                           = prettyType (LocType p (TTake (Just ls) (LocType p (TVariant ts' )))) x
+                                       | otherwise
+                                           = let rest = foldMap id x
                                                  row (g,ts) s = let t' = listTypes ts in [shamlet|<tr><td>#{s}</td><td class='fg-Dull-Magenta spaced'>#{g}</td><td class='spaced'>#{t'}</td>|]
-                                                 rows = zipWith row (M.toList ts) $ '<' : repeat '|'
+                                                 rows = zipWith row (M.toList $ fmap fst ts) $ '<' : repeat '|'
                                               in [shamlet|<table>#{rows}<tr><td>></td><td class='spaced' colspan=2>#{rest}</td><td></td></tr>|]
 prettyType (LocType p (TRecord ts Unboxed))  x = prettyType (LocType p (TUnbox (LocType p (TRecord ts Writable)))) x
 prettyType (LocType p (TRecord ts ReadOnly)) x = prettyType (LocType p (TBang (LocType p (TRecord ts Writable)))) x

--- a/cogent/COGENT/Parser.hs
+++ b/cogent/COGENT/Parser.hs
@@ -113,7 +113,7 @@ pattern = avoidInitial >>
 --            | var
 --            | Con
 
-docHunk = do whiteSpace; try (string "@"); x <- manyTill anyChar newline; whiteSpace; return x
+docHunk = do whiteSpace; _ <- try (string "@"); x <- manyTill anyChar newline; whiteSpace; return x
 monotype = do avoidInitial
               t1 <- typeA1
               t2 <- optionMaybe (reservedOp "->" >> typeA1)
@@ -156,13 +156,13 @@ monotype = do avoidInitial
               -- <|> TCon <$> typeConName <*> pure [] <*> pure Writable
               <|> tuple <$> parens (monotype `sepBy` comma)
               <|> TRecord <$> braces (commaSep1 ((\a b c -> (a,(b,c))) <$> variableName <* reservedOp ":" <*> monotype <*> pure False)) <*> pure Writable
-              <|> TVariant . M.fromList <$> angles (((,) <$> typeConName <*> many typeA2) `sepBy` reservedOp "|"))
+              <|> TVariant . M.fromList <$> angles (((,) <$> typeConName <*> fmap ((,False)) (many typeA2)) `sepBy` reservedOp "|"))
     tuple [] = TUnit
     tuple [e] = typeOfLT e
     tuple es  = TTuple es
 
-    fList = (Just . (:[])) <$> variableName
-        <|> parens ((reservedOp ".." >> return Nothing) <|> (commaSep variableName >>= return . Just))
+    fList = (Just . (:[])) <$> identifier 
+        <|> parens ((reservedOp ".." >> return Nothing) <|> (commaSep identifier >>= return . Just))
 
 -- XXX | monotype = avoidInitial >> buildExpressionParser
 -- XXX |          [ [Prefix  ((\x -> LocType (posOfT x) (TUnbox x)) <$ reservedOp "#")]
@@ -225,7 +225,7 @@ basicExpr m = do e <- basicExpr'
 basicExpr' = avoidInitial >> buildExpressionParser
             [ [postfix ((\f e -> LocExpr (posOfE e) (Member e f)) <$ reservedOp "." <*> variableName)]
             , [Prefix (getPosition >>= \p -> reserved "upcast"     *> pure (LocExpr p . Upcast))] 
-            , [Prefix (getPosition >>= \p -> reserved "widen"      *> pure (LocExpr p . Widen ))] 
+--            , [Prefix (getPosition >>= \p -> reserved "widen"      *> pure (LocExpr p . Widen ))] 
             , [Prefix (getPosition >>= \p -> reserved "complement" *> pure (LocExpr p . PrimOp "complement" . (:[])))]
             , [Prefix (getPosition >>= \p -> reserved "not" *> pure (LocExpr p . PrimOp "not" . (:[])))]
             , [Infix (pure (\a b -> LocExpr (posOfE a) (App a b))) AssocLeft]

--- a/cogent/COGENT/PrettyPrint.hs
+++ b/cogent/COGENT/PrettyPrint.hs
@@ -231,7 +231,7 @@ instance (ExprType e, Pretty t, PrettyName pv, Pretty e) => Pretty (Expr t pv e)
      | NoAssoc   l  <- associativity n = pretty' l a <+> primop n <+> pretty' l  b
   pretty (PrimOp n [e])      = primop n <+> pretty' 1 e
   pretty (PrimOp n es)       = primop n <+> tupled (map pretty es)
-  pretty (Widen e)           = keyword "widen"  <+> pretty' 1 e
+  -- pretty (Widen e)           = keyword "widen"  <+> pretty' 1 e
   pretty (Upcast e)          = keyword "upcast" <+> pretty' 1 e
   pretty (App a b)           = pretty' 2 a <+> pretty' 1 b
   pretty (Con n [] )         = tagname n
@@ -287,9 +287,13 @@ instance (Pretty t, TypeType t) => Pretty (Type t) where
                <+> typesymbol "take" <+> tupled1 (map fieldname tk)) &
                (if __cogent_fdisambiguate_pp then (<+> comment "{- rec -}") else id)
         where tk = map fst $ filter (snd .snd) ts
+  pretty (TVariant ts) | any snd ts = let
+     names = map fst $ filter (snd . snd) $ M.toList ts
+   in pretty (TVariant $ fmap (second (const False)) ts) <+> typesymbol "take"
+                                                         <+> tupled1 (map fieldname names)
   pretty (TVariant ts) = variant (map (\(a,bs) -> case bs of
                                           [] -> tagname a
-                                          _  -> tagname a <+> spaceList (map prettyT' bs)) $ M.toList ts)
+                                          _  -> tagname a <+> spaceList (map prettyT' bs)) $ M.toList (fmap fst ts))
     where prettyT' e | not $ isAtomic e = parens (pretty e)
                      | otherwise        = pretty e
   pretty (TFun t t') = prettyT' t <+> typesymbol "->" <+> pretty t'
@@ -318,7 +322,7 @@ instance Pretty RawType where
 instance Pretty TCType where
   pretty (T t) = pretty t
   pretty (U v) = warn ("?" ++ show v)
-  pretty (RemoveCase a b) = pretty a <+> string "(without pattern" <+> pretty b <+> string ")"
+--  pretty (RemoveCase a b) = pretty a <+> string "(without pattern" <+> pretty b <+> string ")"
 
 instance Pretty LocType where
   pretty t = pretty (stripLocT t)
@@ -346,6 +350,7 @@ prettyConstDef typeSigs v t e  = (if typeSigs then ( funname v <+> symbol ":" <+
                                          (funname v <+> group (indent (symbol "=" <+> pretty e)))
 
 instance (Pretty t, PrettyName b, Pretty e) => Pretty (TopLevel t b e) where
+  pretty (DocBlock {}) = string ""
   pretty (TypeDec n vs t) = keyword "type" <+> typename n <> hcat (map ((space <>) . typevar) vs)
                                            <+> indent (symbol "=" </> pretty t)
   pretty (FunDef v pt alts) = prettyFunDef True v pt alts
@@ -420,15 +425,17 @@ instance Pretty TypeError where
   pretty (TakeFromNonRecord fs t)        = err "Cannot" <+> keyword "take" <+> err "fields"
                                            <+> (case fs of Nothing  -> tupled (fieldname ".." : [])
                                                            Just fs' -> tupled1 (map fieldname fs'))
-                                           <+> err "from non record type:"
+                                           <+> err "from non record/variant type:"
                                            <$> pretty t
   pretty (PutToNonRecord fs t)           = err "Cannot" <+> keyword "put" <+> err "fields"
                                            <+> (case fs of Nothing  -> tupled (fieldname ".." : [])
                                                            Just fs' -> tupled1 (map fieldname fs'))
-                                           <+> err "into non record type:"
+                                           <+> err "into non record/variant type:"
                                            <$> pretty t
   pretty (RemoveCaseFromNonVariant p t)  = err "Cannot remove pattern" <$> pretty p <$> err "from type" <$> pretty t
-
+  pretty (DiscardWithoutMatch t)         = err "Variant tag"<+> tagname t <+> err "cannot be discarded without matching on it."
+  pretty (RequiredTakenTag t)            = err "Required variant" <+> tagname t <+> err "but it has already been matched."
+  
 instance Pretty TypeWarning where
   pretty DummyWarning = __fixme $ warn "WARNING: dummy"
 

--- a/cogent/COGENT/Surface.hs
+++ b/cogent/COGENT/Surface.hs
@@ -70,7 +70,7 @@ data Expr t pv e = PrimOp OpName [e]
                  | UnboxedRecord [(FieldName, e)]
                  | Let [Binding t pv e] e
                  | Upcast e
-                 | Widen  e
+--                 | Widen  e
                  | Put e [Maybe (FieldName, e)]  -- Note: `Nothing' will be desugared to `Just' in TypeCheck / zilinc
                  deriving (Show, Functor, Foldable, Traversable)
 
@@ -83,12 +83,13 @@ data Type t =
             | TVar VarName Banged
             | TFun t t
             | TRecord [(FieldName, (t, Taken))] Sigil
-            | TVariant (M.Map TagName [t])
+            | TVariant (M.Map TagName ([t], Taken))
             | TTuple [t]
             | TUnit
             -- They will be eliminated at some point / zilinc
             | TUnbox   t
             | TBang    t
+            -- Used for both field names in records and tag names in variants
             | TTake (Maybe [FieldName]) t
             | TPut  (Maybe [FieldName]) t
             deriving (Show, Functor, Eq, Foldable, Traversable)
@@ -163,7 +164,7 @@ instance Traversable (Flip (Expr t) e) where
   traverse _ (Flip (UnboxedRecord es))  = pure $ Flip (UnboxedRecord es)
   traverse _ (Flip (Put e es))          = pure $ Flip (Put e es)
   traverse _ (Flip (Upcast e))          = pure $ Flip (Upcast e)
-  traverse _ (Flip (Widen e))           = pure $ Flip (Widen e)
+  -- traverse _ (Flip (Widen e))           = pure $ Flip (Widen e)
 instance Functor (Flip (Binding t) e) where
   fmap f x = runIdentity (traverse (Identity . f) x)
 instance Functor (Flip Alt e) where
@@ -199,7 +200,7 @@ instance Traversable (Flip2 Expr p e) where
   traverse _ (Flip2 (Tuple es))         = pure $ Flip2 (Tuple es)
   traverse _ (Flip2 (UnboxedRecord es)) = pure $ Flip2 (UnboxedRecord es)
   traverse _ (Flip2 (Put e es))         = pure $ Flip2 (Put e es)
-  traverse _ (Flip2 (Widen e))          = pure $ Flip2 (Widen e)
+  --traverse _ (Flip2 (Widen e))          = pure $ Flip2 (Widen e)
   traverse _ (Flip2 (Upcast e))         = pure $ Flip2 (Upcast e)
 instance Functor (Flip (TopLevel t) e) where
   fmap f x = runIdentity (traverse (Identity . f) x)

--- a/cogent/COGENT/TypeCheck/Generator.hs
+++ b/cogent/COGENT/TypeCheck/Generator.hs
@@ -123,11 +123,11 @@ cg' (Upcast e) t = do
   let c = (T (TCon "U8" [] Unboxed) :<~ alpha) <> alpha :<~ t <> c1
   return (c, Upcast e1')
 
-cg' (Widen e) t = do
-  alpha <- fresh
-  (c1, e1') <- cg e alpha
-  let c = (T (TVariant M.empty) :<~ alpha) <> (alpha :<~ t) <> c1
-  return (c, Widen e1')
+-- cg' (Widen e) t = do
+--   alpha <- fresh
+--   (c1, e1') <- cg e alpha
+--   let c = (T (TVariant M.empty) :<~ alpha) <> (alpha :<~ t) <> c1
+--   return (c, Widen e1')
 
 cg' (BoolLit b) t = do
   let c = T (TCon "Bool" [] Unboxed) :< t
@@ -171,7 +171,7 @@ cg' (Con k es) t = do
   (ts, c', es') <- cgMany es
 
   let e = Con k es'
-      c = c' <> T (TVariant (M.fromList [(k, ts)])) :<~ t
+      c = c' <> T (TVariant (M.fromList [(k, (ts, False))])) :<~ t
   return (c,e)
 
 cg' (Tuple es) t = do
@@ -277,7 +277,7 @@ cgAlts alts top alpha = do
       context %= C.addScope s
       (c', e') <- cg e top
       context %= C.dropScope
-      return (RemoveCase p' t, (c <> c', Alt p' like e'))
+      return (removeCase p t, (c <> c', Alt p' like e'))
 
     jobs = map (\(n, alt) -> (NthAlternative n (altPattern alt), f alt)) (zip [1..] alts)
 
@@ -302,7 +302,7 @@ matchA (PCon k is) t = do
       co = case overlapping ss of
              Left (v:vs) -> Unsat $ DuplicateVariableInPattern v p'
              _           -> Sat
-  return (M.unions ss, co <> mconcat cs <> T (TVariant (M.fromList [(k, vs)])) :<~ t, p')
+  return (M.unions ss, co <> mconcat cs <> T (TVariant (M.fromList [(k, (vs, False))])) :<~ t, p')
 
 matchA (PIntLit i) t = do
   let minimumBitwidth | i < u8MAX      = "U8"

--- a/cogent/COGENT/TypeCheck/Post.hs
+++ b/cogent/COGENT/TypeCheck/Post.hs
@@ -20,7 +20,7 @@ import COGENT.Util
 import Control.Monad
 import Control.Lens
 import Control.Monad.Except
-
+import qualified Data.Map as M
 postT :: [ErrorContext] -> TCType -> ExceptT [ContextualisedError] TC RawType
 postT ctx t = do
   d <- use knownTypes
@@ -83,10 +83,11 @@ normaliseT d (T (TTake fs t)) = do
    t' <- normaliseT d t
    case t' of
      (T (TRecord l s)) -> normaliseT d (T (TRecord (takeFields fs l) s))
+     (T (TVariant ts)) -> normaliseT d (T (TVariant (M.fromList $ takeFields fs $ M.toList ts)))
      _ | Just fs' <- fs, null fs' -> Right t'
      e                 -> Left (TakeFromNonRecord fs t)
  where
-   takeFields :: Maybe [FieldName] -> [(FieldName, (TCType, Bool))] -> [(FieldName, (TCType, Bool))]
+   takeFields :: Maybe [FieldName] -> [(FieldName, (a, Bool))] -> [(FieldName, (a, Bool))]
    takeFields Nothing   = map (fmap (fmap (const True)))
    takeFields (Just fs) = map (\(f, (t, b)) -> (f, (t, f `elem` fs || b)))
 
@@ -94,10 +95,11 @@ normaliseT d (T (TPut fs t)) = do
    t' <- normaliseT d t
    case t' of
      (T (TRecord l s)) -> normaliseT d (T (TRecord (putFields fs l) s))
+     (T (TVariant ts)) -> normaliseT d (T (TVariant (M.fromList $ putFields fs $ M.toList ts)))
      _ | Just fs' <- fs, null fs'  -> Right t'
      e                 -> Left (PutToNonRecord fs t)
  where
-   putFields :: Maybe [FieldName] -> [(FieldName, (TCType, Bool))] -> [(FieldName, (TCType, Bool))]
+   putFields :: Maybe [FieldName] -> [(FieldName, (a, Bool))] -> [(FieldName, (a, Bool))]
    putFields Nothing   = map (fmap (fmap (const False)))
    putFields (Just fs) = map (\(f, (t, b)) -> (f, (t,  (f `notElem` fs) && b)))
 
@@ -106,12 +108,12 @@ normaliseT d (T (TCon n ts b)) = do
     Just (ts', Just b) -> normaliseT d (substType (zip ts' ts) b)
     _ -> mapM (normaliseT d) ts >>= \ts' -> return (T (TCon n ts' b))
 
-normaliseT d (RemoveCase p t) = do
-  t' <- normaliseT d t
-  p' <- traverse (traverse (normaliseT d)) p
-  case removeCase p' t' of
-    Just t'' -> normaliseT d t''
-    Nothing  -> Left (RemoveCaseFromNonVariant p t)
+-- normaliseT d (RemoveCase p t) = do
+--   t' <- normaliseT d t
+--   p' <- traverse (traverse (normaliseT d)) p
+--   case removeCase p' t' of
+--     Just t'' -> normaliseT d t''
+--     Nothing  -> Left (RemoveCaseFromNonVariant p t)
 
 normaliseT d (U x) = error "Panic: invalid type to normaliseT"
 normaliseT d (T x) = T <$> traverse (normaliseT d) x

--- a/cogent/COGENT/TypeCheck/Solver.hs
+++ b/cogent/COGENT/TypeCheck/Solver.hs
@@ -90,10 +90,11 @@ whnf (T (TTake fs t)) = do
    t' <- whnf t
    return $ case t' of
      (T (TRecord l s)) -> T (TRecord (takeFields fs l) s)
+     (T (TVariant l))  -> T (TVariant (M.fromList $ takeFields fs $ M.toList l))
      _ | Just fs' <- fs, null fs'  -> t'
      _                 -> T (TTake fs t')
  where
-   takeFields :: Maybe [FieldName] -> [(FieldName, (TCType, Bool))] -> [(FieldName, (TCType, Bool))]
+   takeFields :: Maybe [FieldName] -> [(FieldName, (a , Bool))] -> [(FieldName, (a, Bool))]
    takeFields Nothing   = map (fmap (fmap (const True)))
    takeFields (Just fs) = map (\(f, (t, b)) -> (f, (t, f `elem` fs || b)))
 
@@ -101,10 +102,11 @@ whnf (T (TPut fs t)) = do
    t' <- whnf t
    return $ case t' of
      (T (TRecord l s)) -> T (TRecord (putFields fs l) s)
+     (T (TVariant l))  -> T (TVariant (M.fromList $ putFields fs $ M.toList l))
      _ | Just fs' <- fs, null fs'  -> t'
      _                 -> T (TPut fs t')
  where
-   putFields :: Maybe [FieldName] -> [(FieldName, (TCType, Bool))] -> [(FieldName, (TCType, Bool))]
+   putFields :: Maybe [FieldName] -> [(FieldName, (a, Bool))] -> [(FieldName, (a, Bool))]
    putFields Nothing   = map (fmap (fmap (const False)))
    putFields (Just fs) = map (\(f, (t, b)) -> (f, (t,  (f `notElem` fs) && b)))
 
@@ -114,9 +116,6 @@ whnf (T (TCon n as b)) = do
     Just (as', Just b) -> whnf (substType (zip as' as) b)
     _ -> return (T (TCon n as b))
 
-whnf (RemoveCase p t) = do
-  t' <- whnf t
-  return $ fromMaybe (RemoveCase p t') (removeCase p t')
 whnf t = return t
 
 
@@ -128,7 +127,6 @@ notWhnf (T TPut   {})    = True
 notWhnf (T TUnbox {})    = True
 notWhnf (T TBang  {})    = True
 notWhnf (U u)            = True
-notWhnf (RemoveCase t p) = True
 notWhnf _                = False
 
 isIrrefutable :: Pattern n -> Bool
@@ -153,7 +151,7 @@ rule :: Constraint -> Maybe Constraint
 rule (Exhaustive t ps) | any isIrrefutable ps = Just Sat
 rule (Exhaustive (T (TVariant n)) ps)
   | s1 <- S.fromList (mapMaybe patternTag ps)
-  , s2 <- M.keysSet n
+  , s2 <- S.fromList (map fst $ filter (not . snd . snd) $ M.toList n)
   = if s1 == s2
     then Just Sat
     else Just $ Unsat (PatternsNotExhaustive (T (TVariant n)) (S.toList (s2 S.\\ s1)))
@@ -191,9 +189,9 @@ rule (Share  (T TFun {}) m) = Just Sat
 rule (Escape (T TFun {}) m) = Just Sat
 rule (Drop   (T TFun {}) m) = Just Sat
 
-rule (Share  (T (TVariant n)) m) = Just $ foldMap (mconcat . map (flip Share m)) n
-rule (Drop   (T (TVariant n)) m) = Just $ foldMap (mconcat . map (flip Drop  m)) n
-rule (Escape (T (TVariant n)) m) = Just $ foldMap (mconcat . map (flip Escape m)) n
+rule (Share  (T (TVariant n)) m) = Just $ foldMap (\(ts, t) -> if t then Sat else mconcat $ map (flip Share  m) ts) n
+rule (Drop   (T (TVariant n)) m) = Just $ foldMap (\(ts, t) -> if t then Sat else mconcat $ map (flip Drop   m) ts) n
+rule (Escape (T (TVariant n)) m) = Just $ foldMap (\(ts, t) -> if t then Sat else mconcat $ map (flip Escape m) ts) n
 
 rule (Share  t@(T (TRecord fs s)) m)
   | s /= Writable = Just $ foldMap (\(x, t) -> if not t then Share x m else Sat) $ map snd fs
@@ -239,8 +237,11 @@ rule (T (TRecord fs s) :< T (TRecord gs r))
 rule (T (TVariant m) :< T (TVariant n))
   | M.keys m /= M.keys n = Just $ Unsat (TypeMismatch (T (TVariant m)) (T (TVariant n)))
   | otherwise = let
-      each ts us = mconcat (zipWith (:<) ts us)
-    in Just $ mconcat (zipWith (each `on` snd) (M.toList m) (M.toList n))
+      each (f, (ts, False)) (_, (us, True )) = Unsat (DiscardWithoutMatch f) 
+      each (f, (ts, True )) (_, (us, True )) = mconcat (zipWith (:<) ts us)
+      each (f, (ts, False)) (_, (us, False)) = mconcat (zipWith (:<) ts us)
+      each (f, (ts, True )) (_, (us, False)) = mconcat (zipWith (:<) ts us)
+    in Just $ mconcat (zipWith (each) (M.toList m) (M.toList n))
 -- This rule is a bit dodgy
 -- rule (T (TTake (Just a) b) :< T (TTake (Just a') c))
 --   | x <- L.intersect a a'
@@ -263,8 +264,9 @@ rule (T (TCon n [] Unboxed) :<~ T (TCon m [] Unboxed))
 rule (T (TVariant n) :<~ T (TVariant m))
   | ks <- M.keysSet n
   , ks `S.isSubsetOf` M.keysSet m
-  = let each ts us = mconcat (zipWith (:<) ts us)
-    in Just $ mconcat (map (\k -> each (n M.! k) (m M.! k)) $ S.toList ks)
+  = let each t (ts, _) (us, False)  = mconcat (zipWith (:<) ts us)
+        each t (ts, _) (us, True)   = Unsat (RequiredTakenTag t)
+    in Just $ mconcat (map (\k -> each k (n M.! k) (m M.! k)) $ S.toList ks)
 rule (T (TRecord fs _) :<~ T (TRecord gs s))
   | ks <- S.fromList (map fst fs)
   , m <- M.fromList gs
@@ -321,7 +323,14 @@ glb (T (TVariant is)) (T (TVariant js))
   | or (zipWith ((/=) `on` length) (F.toList is) (F.toList js))
   = return Nothing
   | otherwise
-  = Just . T . TVariant <$> traverse (\l -> replicateM (length l) fresh) is
+  = Just . T . TVariant . M.fromList <$> traverse each (M.keys is)
+  where
+    each :: TagName -> Solver (TagName, ([TCType], Taken))
+    each k = let
+      (i, ib) = is M.! k
+      (j, jb) = js M.! k
+     in do ts <- replicateM (length i) fresh
+           return (k, (ts, ib || jb))
 glb (T (TTuple is)) (T (TTuple js))
   | length is /= length js = return Nothing
   | otherwise = Just . T . TTuple <$> traverse (const fresh) is
@@ -354,7 +363,14 @@ lub (T (TVariant is)) (T (TVariant js))
   | or (zipWith ((/=) `on` length) (F.toList is) (F.toList js))
   = return Nothing
   | otherwise
-  = Just . T . TVariant <$> traverse (\l -> replicateM (length l) fresh) is
+  = Just . T . TVariant . M.fromList <$> traverse each (M.keys is)
+  where
+    each :: TagName -> Solver (TagName, ([TCType], Taken))
+    each k = let
+      (i, ib) = is M.! k
+      (j, jb) = js M.! k
+     in do ts <- replicateM (length i) fresh
+           return (k, (ts, ib && jb))
 lub (T (TTuple is)) (T (TTuple js))
   | length is /= length js = return Nothing
   | otherwise = Just . T . TTuple <$> traverse (const fresh) is
@@ -429,14 +445,14 @@ instance Monoid GoalClasses where
   mempty = Classes M.empty M.empty M.empty [] []
 
 exhaustives :: Goal -> Solver Goal
-exhaustives (Goal ctx (Exhaustive (U x) ps)) | all isVarCon ps = do
-        ts <- fromPatterns ps
-        return (Goal [] $ U x :< T (TVariant ts))
-  where
-    fromPattern :: Pattern TCName -> Solver (M.Map TagName [TCType])
-    fromPattern (PCon t ps) = M.singleton t <$> (mapM (const fresh) ps)
-    fromPattern _ = error "impossible"
-    fromPatterns ps = mconcat <$> mapM fromPattern ps
+-- exhaustives (Goal ctx (Exhaustive (U x) ps)) | all isVarCon ps = do
+--         ts <- fromPatterns ps
+--         return (Goal [] $ U x :< T (TVariant ts))
+--   where
+--     fromPattern :: Pattern TCName -> Solver (M.Map TagName [TCType])
+--     fromPattern (PCon t ps) = M.singleton t <$> (mapM (const fresh) ps)
+--     fromPattern _ = error "impossible"
+--     fromPatterns ps = mconcat <$> mapM fromPattern ps
 exhaustives x = return x
 
 -- Break goals into their form

--- a/cogent/tests/pass_case-default-constructor.cogent
+++ b/cogent/tests/pass_case-default-constructor.cogent
@@ -14,4 +14,4 @@ foo : Variant -> Variant
 foo v = v
       | Tag_a x -> Tag_a x
       | Tag_b x -> Tag_b x
-      | d       -> widen d
+      | d       -> d

--- a/cogent/tests/pass_case-default.cogent
+++ b/cogent/tests/pass_case-default.cogent
@@ -18,7 +18,7 @@ type V = < TAG_a U8 | TAG_b U32 | TAG_c T >
 @ A function to test pattern matching *facilities*. 
 yyy : (V! @ a banged V argument
       , U32 @ *also able to use markdown* 
-      ) -> < Fail (U32, < TAG_a U8 | TAG_c T >!)  @ we failed :(
+      ) -> < Fail (U32, (<TAG_a U8 | TAG_b U32 | TAG_c T > take TAG_b)!)  @ we failed :(
            | Success U32 @ we succeeded `yay`
            >
 yyy (v, y) =
@@ -52,7 +52,7 @@ foo v =
 
 @@## Subheading 31
 
-bar : < TAG_a U8 | TAG_b U16 | TAG_c U32 >! -> < Fail (U32, < TAG_b U16 | TAG_c U32 >!) 
+bar : < TAG_a U8 | TAG_b U16 | TAG_c U32 >! -> < Fail (U32, (< TAG_a U8 | TAG_b U16 | TAG_c U32 > take TAG_a)!) 
                                                | Success (U8) >
 bar v =
    v

--- a/cogent/tests/pass_case-literal-default.cogent
+++ b/cogent/tests/pass_case-literal-default.cogent
@@ -9,6 +9,6 @@
 --
 
 foo : < TAG_a U8 | TAG_b U16 | TAG_c U32 > 
-   -> < Success < TAG_x U8 | TAG_y < TAG_b U16 | TAG_c U32 > > >
+   -> < Success < TAG_x U8 | TAG_y (< TAG_a U8 | TAG_b U16 | TAG_c U32 > take TAG_a) > >
 foo | TAG_a va -> Success (TAG_x va)
     | d -> Success (TAG_y d)

--- a/cogent/tests/pass_unboxed-rec-subtyping.cogent
+++ b/cogent/tests/pass_unboxed-rec-subtyping.cogent
@@ -12,8 +12,8 @@ type A
 
 type Option a = <None () | Some a>
 
-foo : <Some A> -> #{f1 : U8, f2 : Option A}
-foo a = #{f1 = 8, f2 = widen a}
+foo : (Option A) take None -> #{f1 : U8, f2 : Option A}
+foo a = #{f1 = 8, f2 = a}
 
 bar : <None ()>
 bar = None ()

--- a/cogent/tests/pass_useability-in-default.cogent
+++ b/cogent/tests/pass_useability-in-default.cogent
@@ -16,7 +16,7 @@ type B = < TAG_t1 T1 | TAG_t2 T2 >
 
 type T = { a : A, b : B } take ()
 
-foo : (T) -> < Fail (U32, { a : A, b : B } take b, < TAG_t2 T2 >) 
+foo : (T) -> < Fail (U32, { a : A, b : B } take b, B take TAG_t1) 
              | Success ({ a : A, b : B } take b, T1) >
 foo (t) =
    let x { b } = t


### PR DESCRIPTION
Implementing the revamped subtyping that should eliminate a lot of redundant copies.

It currently fails two tests with leftover constraints. Still working on why that is the case. It may be WAD, in which case we'll have to see how it goes on real programs before deciding if we want to start guessing types to fix constraints.

`Widen` has been removed, too. 

You can now use `take` and `put` to take/put fields from records AND tags from variants.

The desugarer has just been hacked so it will compile. It may not work correctly. I left TODO tags. 