### PR TITLE
[skelfs] Skel-fs framework.

### DIFF
--- a/build-env.mk
+++ b/build-env.mk
@@ -25,3 +25,13 @@ ISABELLE_BUILD:=$(shell source "$(BUILD_ENV_MK_DIR)"/build-env.sh; echo "$$ISABE
 
 export PATH:=$(shell source "$(BUILD_ENV_MK_DIR)"/build-env.sh; echo "$$PATH")
 
+# Silent by default
+V =
+ifeq ($(strip $(V)),)
+        E = @echo
+        Q = @
+else
+        E = @\#
+        Q =
+endif
+export E Q

--- a/impl/bilby/cogent/Makefile
+++ b/impl/bilby/cogent/Makefile
@@ -115,20 +115,20 @@ PWD:= $(shell pwd)
 default: linux
 
 all: gen $(OBJ)
-	$(CC) -o $(NAME) $(OBJ)
+	$(Q)$(CC) -o $(NAME) $(OBJ)
 
 %.c:
-	$(CC) -c $@
+	$(Q)$(CC) -c $@
 
 # generate executable C code
 .c-gen:
-	cogent $(SRC) -g $(COGENT_FLAGS) \
+	$(Q)cogent $(SRC) -g $(COGENT_FLAGS) \
                 --cpp-args="\$$CPPIN -o \$$CPPOUT -E -P $(EXTRA_CFLAGS)" \
                 --dist-dir=$(DIST_DIR) \
                 --infer-c-funcs="$(ACFILES)"
 
 .verif-gen:
-	cogent $(SRC) -A $(COGENT_FLAGS) \
+	$(Q)cogent $(SRC) -A $(COGENT_FLAGS) \
                 --cpp-args="\$$CPPIN -o \$$CPPOUT -E -P $(EXTRA_CFLAGS)" \
                 --dist-dir=$(DIST_DIR) \
                 --infer-c-funcs="$(ACFILES)" \
@@ -138,50 +138,52 @@ all: gen $(OBJ)
 
 # compile Linux kernel module for file system
 linux: .c-gen
-	$(MAKE) OBJ="$(OBJ)" CFLAGS="$(CFLAGS)" EXTRA_CFLAGS="$(EXTRA_CFLAGS)" -C $(KERNELDIR) M=$(PWD) modules
+	$(Q)$(MAKE) OBJ="$(OBJ)" CFLAGS="$(CFLAGS)" EXTRA_CFLAGS="$(EXTRA_CFLAGS)" -C $(KERNELDIR) M=$(PWD) modules
 
 # generate verification-clean C code and proof scripts
 verification: .verif-gen
-	mv $(DIST_DIR)/generated.table $(DIST_DIR)/wrapper_pp_inferred.table
+	$(Q)mv $(DIST_DIR)/generated.table $(DIST_DIR)/wrapper_pp_inferred.table
 
 clean:
-	rm -f $(HOUTPUT)
-	rm -f $(OBJ)
-	rm -f $(RTMPC)
-	rm -f $(RTMPPPC)
-	rm -f $(MODULE).mod.[co] $(MODULE).o $(MODULE).ko Module.symvers modules.order
-	rm -f abstract/*.h
-	rm -rf *.thy ROOT generated.table BUILD_INFO
-	find . -name *.thy -exec rm -f {} \;
-	find . -name ROOT -exec rm -f {} \;
-	find . -name BUILD_INFO -exec rm -f {} \;
-	find . -name *_pp* -exec rm -f {} \;
-	find . -name generated.* -exec rm -f {} \;
+	$(E) "Cleaning up.."
+	$(Q)rm -f $(HOUTPUT)
+	$(Q)rm -f $(OBJ)
+	$(Q)rm -f $(RTMPC)
+	$(Q)rm -f $(RTMPPPC)
+	$(Q)rm -f $(MODULE).mod.[co] $(MODULE).o $(MODULE).ko Module.symvers modules.order
+	$(Q)rm -f abstract/*.h
+	$(Q)rm -rf *.thy ROOT generated.table BUILD_INFO
+	$(Q)find . -name *.thy -exec rm -f {} \;
+	$(Q)find . -name ROOT -exec rm -f {} \;
+	$(Q)find . -name BUILD_INFO -exec rm -f {} \;
+	$(Q)find . -name *_pp* -exec rm -f {} \;
+	$(Q)find . -name generated.* -exec rm -f {} \;
+	$(Q)find . -name *.cmd -exec rm -f {} \;
 
 help:
-	@echo "** Cogent bilbyfs build help **"
-	@echo "Run 'make' to build the Linux bilbyfs kernel module."
-	@echo ""
-	@echo "Please run 'make <target>' where target is one of the following:"
-	@echo "* linux"
-	@echo "  Build the Linux kernel module(default)."
-	@echo "  This will build against the kernel headers of the current running kernel."
-	@echo "  Pass KERNELDIR=<path-to-kernel-headers> if you want to build against a different kernel version."
-	@echo "  eg.:"
-	@echo "     make linux"
-	@echo "     make linux KERNELDIR=/usr/src/linux-headers-4.3.0-1-amd64/"
-	@echo ""
-	@echo "* debug"
-	@echo "  Build the Linux kernel module with debugging enabled."
-	@echo "  This is equivalent to running 'make linux DEBUG=1'"
-	@echo ""
-	@echo "* verification"
-	@echo "  Generate verification table."
-	@echo ""
-	@echo "* clean"
-	@echo "  Cleanup."
-	@echo ""
-	@echo "* help"
-	@echo "  Print this help."
+	$(E) "** Cogent bilbyfs build help **"
+	$(E) "Run 'make' to build the Linux bilbyfs kernel module."
+	$(E) ""
+	$(E) "Please run 'make <target>' where target is one of the following:"
+	$(E) "* linux"
+	$(E) "  Build the Linux kernel module(default)."
+	$(E) "  This will build against the kernel headers of the current running kernel."
+	$(E) "  Pass KERNELDIR=<path-to-kernel-headers> if you want to build against a different kernel version."
+	$(E) "  eg.:"
+	$(E) "     make linux"
+	$(E) "     make linux KERNELDIR=/usr/src/linux-headers-4.3.0-1-amd64/"
+	$(E) ""
+	$(E) "* debug"
+	$(E) "  Build the Linux kernel module with debugging enabled."
+	$(E) "  This is equivalent to running 'make linux DEBUG=1'"
+	$(E) ""
+	$(E) "* verification"
+	$(E) "  Generate verification table."
+	$(E) ""
+	$(E) "* clean"
+	$(E) "  Cleanup."
+	$(E) ""
+	$(E) "* help"
+	$(E) "  Print this help."
 
 endif

--- a/impl/ext2/cogent/Makefile
+++ b/impl/ext2/cogent/Makefile
@@ -120,20 +120,20 @@ PWD:= $(shell pwd)
 default: linux
 
 all: .c-gen $(OBJ)
-	$(CC) -o $(NAME) $(OBJ)
+	$(Q)$(CC) -o $(NAME) $(OBJ)
 
 %.c:
-	$(CC) -c $@
+	$(Q)$(CC) -c $@
 
 # generate executable C code
 .c-gen:
-	cogent $(SRC) -g $(COGENT_FLAGS) \
+	$(Q)cogent $(SRC) -g $(COGENT_FLAGS) \
 		--cpp-args="\$$CPPIN -o \$$CPPOUT -E -P $(EXTRA_CFLAGS)" \
 		--dist-dir=$(DIST_DIR) \
 		--infer-c-funcs="$(ACFILES)"
 
 .verif-gen:
-	cogent $(SRC) -A $(COGENT_FLAGS) \
+	$(Q)cogent $(SRC) -A $(COGENT_FLAGS) \
 		--cpp-args="\$$CPPIN -o \$$CPPOUT -E -P $(EXTRA_CFLAGS)" \
 		--dist-dir=$(DIST_DIR) \
 		--infer-c-funcs="$(ACFILES)" \
@@ -142,51 +142,53 @@ all: .c-gen $(OBJ)
 
 # compile Linux kernel module for file system
 linux: .c-gen
-	$(MAKE) OBJ="$(OBJ)" CFLAGS="$(CFLAGS)" EXTRA_CFLAGS="$(EXTRA_CFLAGS)" -C $(KERNELDIR) M=$(PWD) modules
+	$(Q)$(MAKE) OBJ="$(OBJ)" CFLAGS="$(CFLAGS)" EXTRA_CFLAGS="$(EXTRA_CFLAGS)" -C $(KERNELDIR) M=$(PWD) modules
 
 # generate verification-clean C code and proof scripts
 verification: .verif-gen
-	mv $(DIST_DIR)/generated.table $(DIST_DIR)/wrapper_pp_inferred.table
+	$(Q)mv $(DIST_DIR)/generated.table $(DIST_DIR)/wrapper_pp_inferred.table
 
 
 clean:
-	rm -f $(HOUTPUT)
-	rm -f $(OBJ)
-	rm -f $(RTMPC)
-	rm -f $(RTMPPPC)
-	rm -f $(MODULE).mod.[co] $(MODULE).o $(MODULE).ko Module.symvers modules.order
-	rm -f abstract/*.h
-	rm -rf *.thy ROOT generated.table BUILD_INFO
-	find . -name *.thy -exec rm -f {} \;
-	find . -name ROOT -exec rm -f {} \;
-	find . -name BUILD_INFO -exec rm -f {} \;
-	find . -name *_pp* -exec rm -f {} \;
-	find . -name generated.* -exec rm -f {} \;
+	$(E) "Cleaning up.."
+	$(Q)rm -f $(HOUTPUT)
+	$(Q)rm -f $(OBJ)
+	$(Q)rm -f $(RTMPC)
+	$(Q)rm -f $(RTMPPPC)
+	$(Q)rm -f $(MODULE).mod.[co] $(MODULE).o $(MODULE).ko Module.symvers modules.order
+	$(Q)rm -f abstract/*.h
+	$(Q)rm -rf *.thy ROOT generated.table BUILD_INFO
+	$(Q)find . -name *.thy -exec rm -f {} \;
+	$(Q)find . -name ROOT -exec rm -f {} \;
+	$(Q)find . -name BUILD_INFO -exec rm -f {} \;
+	$(Q)find . -name *_pp* -exec rm -f {} \;
+	$(Q)find . -name generated.* -exec rm -f {} \;
+	$(Q)find . -name *.cmd -exec rm -f {} \;
 
 help:
-	@echo "** Cogent ext2fs build help **"
-	@echo "Run 'make' to build the Linux ext2fs kernel module."
-	@echo ""
-	@echo "Please run 'make <target>' where target is one of the following:"
-	@echo "* linux"
-	@echo "  Build the Linux kernel module(default)."
-	@echo "  This will build against the kernel headers of the current running kernel."
-	@echo "  Pass KERNELDIR=<path-to-kernel-headers> if you want to build against a different kernel version."
-	@echo "  eg.:"
-	@echo "     make linux"
-	@echo "     make linux KERNELDIR=/usr/src/linux-headers-4.3.0-1-amd64/"
-	@echo ""
-	@echo "* debug"
-	@echo "  Build the Linux kernel module with debugging enabled."
-	@echo "  This is equivalent to running 'make linux DEBUG=1'"
-	@echo ""
-	@echo "* verification"
-	@echo "  Generate verification table."
-	@echo ""
-	@echo "* clean"
-	@echo "  Cleanup."
-	@echo ""
-	@echo "* help"
-	@echo "  Print this help."
+	$(E) "** Cogent ext2fs build help **"
+	$(E) "Run 'make' to build the Linux ext2fs kernel module."
+	$(E) ""
+	$(E) "Please run 'make <target>' where target is one of the following:"
+	$(E) "* linux"
+	$(E) "  Build the Linux kernel module(default)."
+	$(E) "  This will build against the kernel headers of the current running kernel."
+	$(E) "  Pass KERNELDIR=<path-to-kernel-headers> if you want to build against a different kernel version."
+	$(E) "  eg.:"
+	$(E) "     make linux"
+	$(E) "     make linux KERNELDIR=/usr/src/linux-headers-4.3.0-1-amd64/"
+	$(E) ""
+	$(E) "* debug"
+	$(E) "  Build the Linux kernel module with debugging enabled."
+	$(E) "  This is equivalent to running 'make linux DEBUG=1'"
+	$(E) ""
+	$(E) "* verification"
+	$(E) "  Generate verification table."
+	$(E) ""
+	$(E) "* clean"
+	$(E) "  Cleanup."
+	$(E) ""
+	$(E) "* help"
+	$(E) "  Print this help."
 
 endif

--- a/impl/skel-fs/cogent/Makefile
+++ b/impl/skel-fs/cogent/Makefile
@@ -110,20 +110,20 @@ PWD:= $(shell pwd)
 default: linux
 
 all: .c-gen $(OBJ)
-	$(CC) -o $(NAME) $(OBJ)
+	$(Q)$(CC) -o $(NAME) $(OBJ)
 
 %.c:
-	$(CC) -c $@
+	$(Q)$(CC) -c $@
 
 # generate executable C code
 .c-gen:
-	cogent $(SRC) -g $(COGENT_FLAGS) \
+	$(Q)cogent $(SRC) -g $(COGENT_FLAGS) \
 		--cpp-args="\$$CPPIN -o \$$CPPOUT -E -P $(EXTRA_CFLAGS)" \
 		--dist-dir=$(DIST_DIR) \
 		--infer-c-funcs="$(ACFILES)"
 
 .verif-gen:
-	cogent $(SRC) -A $(COGENT_FLAGS) \
+	$(Q)cogent $(SRC) -A $(COGENT_FLAGS) \
 		--cpp-args="\$$CPPIN -o \$$CPPOUT -E -P $(EXTRA_CFLAGS)" \
 		--dist-dir=$(DIST_DIR) \
 		--infer-c-funcs="$(ACFILES)" \
@@ -132,52 +132,54 @@ all: .c-gen $(OBJ)
 
 # compile Linux kernel module for file system
 linux: .c-gen
-	$(MAKE) OBJ="$(OBJ)" CFLAGS="$(CFLAGS)" EXTRA_CFLAGS="$(EXTRA_CFLAGS)" -C $(KERNELDIR) M=$(PWD) modules
+	$(Q) $(MAKE) OBJ="$(OBJ)" CFLAGS="$(CFLAGS)" EXTRA_CFLAGS="$(EXTRA_CFLAGS)" -C $(KERNELDIR) M=$(PWD) modules
 
 # generate verification-clean C code and proof scripts
 verification: .verif-gen
-	mv $(DIST_DIR)/generated.table $(DIST_DIR)/wrapper_pp_inferred.table
+	$(Q)mv $(DIST_DIR)/generated.table $(DIST_DIR)/wrapper_pp_inferred.table
 
 
 clean:
-	rm -f $(HOUTPUT)
-	rm -f $(OBJ)
-	rm -f $(RTMPC)
-	rm -f $(RTMPPPC)
-	rm -f $(MODULE).mod.[co] $(MODULE).o $(MODULE).ko Module.symvers modules.order
-	rm -f abstract/*.h
-	rm -rf *.thy ROOT generated.table BUILD_INFO
-	find . -name *.thy -exec rm -f {} \;
-	find . -name ROOT -exec rm -f {} \;
-	find . -name BUILD_INFO -exec rm -f {} \;
-	find . -name *_pp* -exec rm -f {} \;
-	find . -name generated.* -exec rm -f {} \;
+	$(E) "Cleaning up.."
+	$(Q) rm -f $(HOUTPUT)
+	$(Q) rm -f $(OBJ)
+	$(Q) rm -f $(RTMPC)
+	$(Q) rm -f $(RTMPPPC)
+	$(Q) rm -f $(MODULE).mod.[co] $(MODULE).o $(MODULE).ko Module.symvers modules.order
+	$(Q) rm -f abstract/*.h
+	$(Q) rm -rf *.thy ROOT generated.table BUILD_INFO
+	$(Q) find . -name *.thy -exec rm -f {} \;
+	$(Q) find . -name ROOT -exec rm -f {} \;
+	$(Q) find . -name BUILD_INFO -exec rm -f {} \;
+	$(Q) find . -name *_pp* -exec rm -f {} \;
+	$(Q) find . -name generated.* -exec rm -f {} \;
+	$(Q)find . -name *.cmd -exec rm -f {} \;
 
 help:
-	@echo "** Cogent skel-fs build help **"
-	@echo "Run 'make' to build the Linux skel-fs kernel module."
-	@echo ""
-	@echo "Please run 'make <target>' where target is one of the following:"
-	@echo "* linux"
-	@echo "  Build the Linux kernel module(default)."
-	@echo "  This will build against the kernel headers of the current running kernel."
-	@echo "  Pass KERNELDIR=<path-to-kernel-headers> if you want to build against a different kernel version."
-	@echo "  eg.:"
-	@echo "     make linux"
-	@echo "     make linux KERNELDIR=/usr/src/linux-headers-4.3.0-1-amd64/"
-	@echo ""
-	@echo "* debug"
-	@echo "  Build the Linux kernel module with debugging enabled."
-	@echo "  This is equivalent to running 'make linux DEBUG=1'"
-	@echo ""
-	@echo "* verification"
-	@echo "  Generate verification table."
-	@echo ""
-	@echo "* clean"
-	@echo "  Cleanup."
-	@echo ""
-	@echo "* help"
-	@echo "  Print this help."
+	$(E) "** Cogent skel-fs build help **"
+	$(E) "Run 'make' to build the Linux skel-fs kernel module."
+	$(E) ""
+	$(E) "Please run 'make <target>' where target is one of the following:"
+	$(E) "* linux"
+	$(E) "  Build the Linux kernel module(default)."
+	$(E) "  This will build against the kernel headers of the current running kernel."
+	$(E) "  Pass KERNELDIR=<path-to-kernel-headers> if you want to build against a different kernel version."
+	$(E) "  eg.:"
+	$(E) "     make linux"
+	$(E) "     make linux KERNELDIR=/usr/src/linux-headers-4.3.0-1-amd64/"
+	$(E) ""
+	$(E) "* debug"
+	$(E) "  Build the Linux kernel module with debugging enabled."
+	$(E) "  This is equivalent to running 'make linux DEBUG=1'"
+	$(E) ""
+	$(E) "* verification"
+	$(E) "  Generate verification table."
+	$(E) ""
+	$(E) "* clean"
+	$(E) "  Cleanup."
+	$(E) ""
+	$(E) "* help"
+	$(E) "  Print this help."
 
 endif
 

--- a/impl/skel-fs/cogent/data/README.md
+++ b/impl/skel-fs/cogent/data/README.md
@@ -1,0 +1,7 @@
+This directory contains two files:
+
+* defns.txt - A file containing a list of Cogent functions that are called externally.
+
+* types.txt - A file containing a list of external type names to Cogent's C parser.
+
+The names of the files could be anything, but ensure that the `Makefile`(one level above) reflects those changes in the `DEFNS` and `TYPES` variables.

--- a/impl/skel-fs/cogent/plat/linux/module.c
+++ b/impl/skel-fs/cogent/plat/linux/module.c
@@ -10,14 +10,45 @@
 
 #include <plat/linux/wrapper_pp_inferred.c>
 
+static struct dentry *skelfs_mount(struct file_system_type *fs_type, int flags,
+                                   const char *dev_name, void *data)
+{
+        return mount_bdev(fs_type, flags, dev_name, data, skelfs_fill_super);
+}
+
+static void kill_skelfs_super(struct super_block *sb)
+{
+        /* TODO: implement filesystem specific super block tear-down here. */
+        kill_block_super(sb);
+}
+
+static struct file_system_type skelfs_fs_type = {
+        .owner    = THIS_MODULE,
+        .name     = "cogent-skelfs",
+        .mount    = skelfs_mount,
+        .kill_sb  = kill_skelfs_super,
+        .fs_flags = FS_REQUIRES_DEV
+};
+
 static int __init init_skel_fs(void)
 {
-        return 0;
+        int err = 0;
+
+        printk(KERN_INFO "Registering SKEL-FS!\n");
+
+        /* TODO: Implement filesystem specific init functions here. */
+        err = register_filesystem(&skelfs_fs_type);
+
+        return err;
 }
 
 
 static void __exit exit_skel_fs(void)
 {
+        printk(KERN_INFO "Un-Registering SKEL-FS!\n");
+
+        /* TODO: Implement filesystem specific tear-down functions here. */
+        unregister_filesystem(&skelfs_fs_type);
 }
 
 

--- a/impl/skel-fs/cogent/plat/linux/wrapper.ac
+++ b/impl/skel-fs/cogent/plat/linux/wrapper.ac
@@ -13,3 +13,13 @@ $esc:(#include <wrapper.h>)
 
 #include <abstract.h>
 #include <generated.c>
+
+
+static int skelfs_fill_super(struct super_block *sb, void *data, int silent)
+{
+        int err = -EINVAL;
+
+        /* XXX: Implement this. */
+
+        return err;
+}


### PR DESCRIPTION
Add entry and exit functions to the various `super_block`, `file_operations`
and `inode_operations` structures.
The idea is to provide a framework of sorts that can be used to implement an
actual filesystem, by implementing the missing pieces, with the grunt work
already done.

This commit also adds support for verbose mode for Makefiles.