### PR TITLE
[compiler] GHC 8.0 support and other fixes.

### DIFF
--- a/cogent/cabal.project
+++ b/cogent/cabal.project
@@ -1,0 +1,3 @@
+packages: *.cabal
+          ../isa-parser/*.cabal
+

--- a/cogent/cogent.cabal
+++ b/cogent/cogent.cabal
@@ -70,19 +70,20 @@ Library
               , Cogent.Vec
 
   other-modules:
+              Data.Monoid.Cancellative
                -- Generated
-                Version_cogent
+              , Version_cogent
               , Paths_cogent
 
   build-depends:
                 ansi-terminal >= 0.6
               , ansi-wl-pprint >= 0.6
               , atomic-write >= 0.2.0.4
-              , base >= 4.7 && < 4.9
+              , base >= 4.7 && < 4.10
               , bifunctors >= 4.2
               , bytestring >= 0.10
               , containers >= 0.5
-              , directory >=1.2 && <= 1.2.2.0
+              , directory >=1.2 && <= 1.3
               , disassembler >= 0.2.0.0
               , either >= 4.3.2
               , extra >= 1.3
@@ -93,17 +94,17 @@ Library
               , hscurses >= 1.4
               , isa-parser >= 0.1.0.0
               , language-c >= 0.4
-              , language-c-quote >= 0.10.2 && < 0.12
+              , language-c-quote >= 0.10.2
               , lens >= 4.6
               , mainland-pretty >= 0.2.6
               , MissingH >= 1.3
-              , monoid-subclasses >= 0.4
+              --- , monoid-subclasses >= 0.4
               , mtl >= 2.2.1
               , parsec >= 3.0
               , pretty-show >= 1.5
               , process >= 1.2.0.0
               , random >= 1.1
-              , reducers >= 3.10 && < 3.12.2
+              , reducers >= 3.10
               , srcloc >= 0.4
               , syb >= 0.3.7
               , template-haskell >= 2.9
@@ -121,15 +122,15 @@ Library
             , happy
   ghc-options:
     -Wall
-    -Werror
+    -- -Werror
     -fno-warn-name-shadowing
     -fno-warn-missing-signatures
     -fno-warn-unused-matches
     -O2
     -- -rtsopts
     -- +RTS -K256M
-  if impl(ghc >= 7.10.1)
-    ghc-options: -fno-warn-unticked-promoted-constructors
+  -- if impl(ghc >= 7.10.1)
+  --  ghc-options: -fno-warn-unticked-promoted-constructors
 
 
 executable cogent
@@ -140,9 +141,9 @@ executable cogent
                 cogent
               , ansi-wl-pprint >= 0.6
               , atomic-write >= 0.2.0.4
-              , base >= 4.7 && < 4.9
+              , base >= 4.7 && < 4.10
               , containers >= 0.5
-              , directory >=1.2 && <= 1.2.2.0
+              , directory >=1.2 && <= 1.3
               , either >= 4.3.2
               , filepath >= 1.4.0.0
               , mainland-pretty >= 0.2.6
@@ -159,15 +160,15 @@ executable cogent
             , happy
   ghc-options:
     -Wall
-    -Werror
+    -- -Werror
     -fno-warn-name-shadowing
     -fno-warn-missing-signatures
     -fno-warn-unused-matches
     -O2
     -- -rtsopts
     -- +RTS -K256M
-  if impl(ghc >= 7.10.1)
-    ghc-options: -fno-warn-unticked-promoted-constructors
+  -- if impl(ghc >= 7.10.1)
+  --  ghc-options: -fno-warn-unticked-promoted-constructors
 
 
 test-suite test-util
@@ -177,7 +178,7 @@ test-suite test-util
   main-is: test-util.hs
   build-depends:
                 cogent
-              , base >= 4.7 && < 4.9
+              , base >= 4.7 && < 4.10
               , containers >= 0.5
               , directory >=1.2
               , filepath >= 1.4.0.0

--- a/cogent/src/Cogent/Compiler.hs
+++ b/cogent/src/Cogent/Compiler.hs
@@ -28,6 +28,8 @@ __impossible msg = error $ msg ++ ": the 'impossible' happened!"
 #if __GLASGOW_HASKELL__ < 711
 __ghc_t4139 :: String -> a
 __ghc_t4139 msg = error $ msg ++ ": GHC doesn't get exhaustivity right (see trac #4139)"
+#else
+
 #endif
 
 __exhaustivity :: String -> a

--- a/cogent/src/Cogent/Desugar.hs
+++ b/cogent/src/Cogent/Desugar.hs
@@ -103,7 +103,7 @@ desugar tls pragmas =
   where fromTypeDec  (S.TypeDec tn vs t) = (tn,(vs,t)); fromTypeDec  _ = __impossible "fromTypeDec (in desugarProgram)"
         fromConstDef (S.ConstDef vn t e) = (vn,e)     ; fromConstDef _ = __impossible "fromConstDef (in desguarProgram)"
 
-withTypeBinding :: TyVarName -> DS (Suc t) v a -> DS t v a
+withTypeBinding :: TyVarName -> DS ('Suc t) v a -> DS t v a
 withTypeBinding t ds = do readers <- ask
                           (tenv,venv,enum) <- get
                           let (a, (_,_,enum'), _) = flip3 runRWS (Cons t tenv, venv, enum) readers $ runDS ds
@@ -114,7 +114,7 @@ withTypeBindings :: Vec k TyVarName -> DS (t :+: k) v a -> DS t v a
 withTypeBindings Nil ds = ds
 withTypeBindings (Cons x xs) ds = withTypeBindings xs (withTypeBinding x ds)
 
-withBinding :: VarName -> DS t (Suc v) a -> DS t v a
+withBinding :: VarName -> DS t ('Suc v) a -> DS t v a
 withBinding v ds = do readers <- ask
                       (tenv,venv,enum) <- get
                       let (a, (_,_,enum'), _) = flip3 runRWS (tenv, Cons v venv, enum) readers $ runDS ds
@@ -138,7 +138,7 @@ pragmaToNote (_:pragmas) fn note = pragmaToNote pragmas fn note
 
 desugarTopLevel :: S.TopLevel S.RawType T.TypedName T.TypedExpr
                 -> [Pragma]
-                -> DS Zero Zero (Maybe (Definition UntypedExpr VarName))
+                -> DS 'Zero 'Zero (Maybe (Definition UntypedExpr VarName))
 desugarTopLevel (S.Include s) _ = __impossible "desugarTopLevel"
 desugarTopLevel (S.IncludeStd s) _ = __impossible "desugarTopLevel"
 desugarTopLevel (S.TypeDec tn vs t) _ | ExI (Flip vs') <- Vec.fromList vs
@@ -525,10 +525,10 @@ desugarOp "<<"  = LShift
 desugarOp "complement" = Complement
 desugarOp x     = __impossible "desugarOp"
 
-desugarConst :: (VarName, T.TypedExpr) -> DS Zero Zero (SFConst UntypedExpr)
+desugarConst :: (VarName, T.TypedExpr) -> DS 'Zero 'Zero (SFConst UntypedExpr)
 desugarConst (n,e) = (n,) <$> desugarExpr e
 
 -- NOTE: aseume the first arguments consists of constants only
-desugarConsts :: [S.TopLevel S.RawType T.TypedName T.TypedExpr] -> DS Zero Zero [SFConst UntypedExpr]
+desugarConsts :: [S.TopLevel S.RawType T.TypedName T.TypedExpr] -> DS 'Zero 'Zero [SFConst UntypedExpr]
 desugarConsts = mapM desugarConst . P.map (\(S.ConstDef v _ e) -> (v,e))
 

--- a/cogent/src/Cogent/Mono.hs
+++ b/cogent/src/Cogent/Mono.hs
@@ -14,7 +14,7 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE ImpredicativeTypes #-}
+--{-# LANGUAGE ImpredicativeTypes #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE MultiWayIf #-}
@@ -49,7 +49,7 @@ import Prelude as P
 -- import Debug.Trace
 
 
-type Instance = [Type Zero]
+type Instance = [Type 'Zero]
 
 -- The list of Definitions is pre-ordered, which means that we only need to visit each definition exactly once.
 -- Traversal has to start from the roots of the call trees to collect instances.
@@ -150,7 +150,7 @@ getPrimInt :: TypedExpr t v VarName -> PrimInt
 getPrimInt (TE t _) | TPrim p <- t = p
                     | otherwise = __impossible "getPrimInt"
 
-monoExpr :: TypedExpr t v VarName -> Mono (TypedExpr Zero v VarName)
+monoExpr :: TypedExpr t v VarName -> Mono (TypedExpr 'Zero v VarName)
 monoExpr (TE t e) = TE <$> monoType t <*> monoExpr' e
   where
     monoExpr' (Variable var       ) = pure $ Variable var
@@ -179,7 +179,7 @@ monoExpr (TE t e) = TE <$> monoType t <*> monoExpr' e
     monoExpr' (Put     rec fld e  ) = Put  <$> monoExpr rec <*> pure fld <*> monoExpr e
     monoExpr' (Promote ty e       ) = Promote <$> monoType ty <*> monoExpr e
 
-monoType :: Type t -> Mono (Type Zero)
+monoType :: Type t -> Mono (Type 'Zero)
 monoType (TVar v) = atList <$> ask <*> pure v
 monoType (TVarBang v) = bang <$> (atList <$> ask <*> pure v)
 monoType (TCon n [] s) = do

--- a/cogent/src/Cogent/MonoProof.hs
+++ b/cogent/src/Cogent/MonoProof.hs
@@ -105,5 +105,5 @@ rename funMono = [isaDecl| definition $alist_name :: "$sig" where "$(mkId alist_
                           then [([isaTerm| $(mkString fn) |], [isaTerm| Nil |], [isaTerm| $(mkString fn) |])]
                           else map (\(tys,num) -> ([isaTerm| $(mkString fn) |], mkTyList tys, [isaTerm| $(mkString $ fn ++ "_" ++ show num) |])) insts
 
-    mkTyList :: [SF.Type Zero] -> Term
+    mkTyList :: [SF.Type 'Zero] -> Term
     mkTyList = I.mkList . map (deepType id (empty, 0))

--- a/cogent/src/Cogent/Normal.hs
+++ b/cogent/src/Cogent/Normal.hs
@@ -99,7 +99,7 @@ normaliseDefinition d = pure d
 normaliseExpr :: SNat v -> UntypedExpr t v VarName -> AN (UntypedExpr t v VarName)
 normaliseExpr v e = normalise v e (\_ x -> return x)
 
-upshiftExpr :: SNat n -> SNat v -> Fin (Suc v) -> UntypedExpr t v a -> UntypedExpr t (v :+: n) a
+upshiftExpr :: SNat n -> SNat v -> Fin ('Suc v) -> UntypedExpr t v a -> UntypedExpr t (v :+: n) a
 upshiftExpr SZero _ _ e = e
 upshiftExpr (SSuc n) sv v e | Refl <- addSucLeft sv n
   = let a = upshiftExpr n sv v e in insertIdxAt (widenN v n) a
@@ -225,10 +225,10 @@ normaliseNames v (e:es) k
       normaliseNames (sadd v n) (map (upshiftExpr n v f0) es) $ \n' es' ->
         withAssoc v n n' $ \Refl -> k (sadd n n') (upshiftExpr n' (sadd v n) f0 e':es')
 
-insertIdxAt :: Fin (Suc v) -> UntypedExpr t v a -> UntypedExpr t (Suc v) a
+insertIdxAt :: Fin ('Suc v) -> UntypedExpr t v a -> UntypedExpr t ('Suc v) a
 insertIdxAt cut (E e) = E $ insertIdxAt' cut e
   where
-    insertIdxAt' :: Fin (Suc v) -> Expr t v a UntypedExpr -> Expr t (Suc v) a UntypedExpr
+    insertIdxAt' :: Fin ('Suc v) -> Expr t v a UntypedExpr -> Expr t ('Suc v) a UntypedExpr
     insertIdxAt' cut (Variable v) = Variable $ (liftIdx cut *** id) v
     insertIdxAt' cut (Fun fn ty nt) = Fun fn ty nt
     insertIdxAt' cut (Op opr es) = Op opr $ map (insertIdxAt cut) es

--- a/cogent/src/Cogent/PrettyCore.hs
+++ b/cogent/src/Cogent/PrettyCore.hs
@@ -121,7 +121,7 @@ instance Pretty a => Pretty (TypedExpr t v a) where
 instance Pretty a => Pretty (UntypedExpr t v a) where
   pretty (E e) = pretty e
 
-instance (Pretty a, PrettyP (e t v a), Pretty (e t (Suc v) a), Pretty (e t (Suc (Suc v)) a))
+instance (Pretty a, PrettyP (e t v a), Pretty (e t ('Suc v) a), Pretty (e t ('Suc ('Suc v)) a))
          => Pretty (Expr t v a e) where
   pretty (Op opr [a,b])
      | LeftAssoc  l <- associativity opr = prettyP (l+1) a <+> primop opr <+> prettyP l b
@@ -206,10 +206,10 @@ instance Pretty a => Pretty (Vec t a) where
   pretty (Cons x Nil) = pretty x
   pretty (Cons x xs) = pretty x <> string "," <+> pretty xs
 
-instance (Pretty a, Pretty (e t (Suc Zero) a)) => Pretty (Definition e a) where
+instance (Pretty a, Pretty (e t ('Suc 'Zero) a)) => Pretty (Definition e a) where
   pretty (FunDef _ fn ts t rt e) = funName fn <+> symbol ":" <+> brackets (pretty ts) <> symbol "." <+>
                                    parens (pretty t) <+> symbol "->" <+> parens (pretty rt) <+> symbol "=" <$>
-                                   pretty (unsafeCoerce e :: e t (Suc Zero) a)  -- FIXME: Use of `unsafeCoerce' to retain existential type / zilinc
+                                   pretty (unsafeCoerce e :: e t ('Suc 'Zero) a)  -- FIXME: Use of `unsafeCoerce' to retain existential type / zilinc
   pretty (AbsDecl _ fn ts t rt) = funName fn <+> symbol ":" <+> brackets (pretty ts) <> symbol "." <+>
                                   parens (pretty t) <+> symbol "->" <+> parens (pretty rt)
   pretty (TypeDef tn ts Nothing) = keyword "type" <+> typename tn <+> pretty ts

--- a/cogent/src/Cogent/ProofGen.hs
+++ b/cogent/src/Cogent/ProofGen.hs
@@ -17,7 +17,9 @@ module Cogent.ProofGen where
 
 import Cogent.Common.Types
 import Cogent.Common.Syntax
+#if __GLASGOW_HASKELL__ < 711
 import Cogent.Compiler
+#endif
 import Cogent.Vec hiding (splitAt, length, zipWith, zip, unzip)
 import qualified Cogent.Vec as Vec
 import Cogent.Sugarfree
@@ -523,7 +525,9 @@ split k g x y = error $ "bad split: " ++ show (g, x, y)
 splitsHint :: Int -> Vec t Kind -> Vec v (Maybe (Type t)) -> Vec v (Maybe (Type t)) -> Vec v (Maybe (Type t)) -> State TypingSubproofs [(Int, [Tactic])]
 splitsHint n k (Cons g gs) (Cons x xs) (Cons y ys) = liftM2 (++) (splitHint n k g x y) (splitsHint (n+1) k gs xs ys)
 splitsHint _ k Nil         Nil         Nil         = return []
+#if __GLASGOW_HASKELL__ < 711
 splitsHint _ _ _ _ _ = __ghc_t4139 "ProofGen.splitsHint"
+#endif
 
 splitHint :: Int -> Vec t Kind -> Maybe (Type t) -> Maybe (Type t) -> Maybe (Type t) -> State TypingSubproofs [(Int, [Tactic])]
 splitHint _ k Nothing  Nothing  Nothing  = return []
@@ -542,8 +546,9 @@ ttsplit_bang k ix ixs (Cons g gs) (Cons Nothing xs) =
     if ix `elem` ixs then error "bad split_bang"
         else ttsplit_bang k (ix + 1) ixs gs xs
 ttsplit_bang k ix ixs Nil Nil = return []
+#if __GLASGOW_HASKELL__ < 711
 ttsplit_bang _ _ _ _ _ = error "bad split_bang end"
-
+#endif
 distinct _ = [simp]
 
 -- K ⊢ τ wellformed ≡ ∃k. K ⊢ τ :κ k
@@ -635,7 +640,7 @@ kindRule (TCon n ts s)    = "kind_tcon"
 envOf = eexprEnv
 typeOf = eexprType
 
-peel :: Vec (Suc v) t -> Vec v t
+peel :: Vec ('Suc v) t -> Vec v t
 peel (Cons x xs) = xs
 
 peel2 = peel . peel
@@ -645,7 +650,9 @@ peel2 = peel . peel
 (<|>) (Cons _ xs)        (Cons (Just y) ys) = Cons (Just y) (xs <|> ys)
 (<|>) (Cons (Just x) xs) (Cons _ ys)        = Cons (Just x) (xs <|> ys)
 (<|>) Nil Nil = Nil
+#if __GLASGOW_HASKELL__ < 711
 (<|>) _ _ = __ghc_t4139 "ProofGen.<|>"
+#endif
 
 cleared :: Vec a (Maybe t) -> Vec a (Maybe t)
 cleared = emptyvec . Vec.length

--- a/cogent/src/Cogent/Shallow.hs
+++ b/cogent/src/Cogent/Shallow.hs
@@ -268,7 +268,7 @@ mkLet nm t1 t2 =
  else
     mkApp (mkId "HOL.Let") [t1, mkLambda [snm nm] t2]
 
-shallowLet :: VarName -> TypedExpr t v VarName -> TypedExpr t (Suc v) VarName -> SG Term
+shallowLet :: VarName -> TypedExpr t v VarName -> TypedExpr t ('Suc v) VarName -> SG Term
 shallowLet nm e1 e2 = mkLet nm <$> shallowExpr e1 <*> shallowExpr e2
 
 mkStr :: [String] -> Term

--- a/cogent/src/Cogent/Sugarfree.hs
+++ b/cogent/src/Cogent/Sugarfree.hs
@@ -105,19 +105,19 @@ data Expr t v a e
   | Unit
   | ILit Integer PrimInt
   | SLit String
-  | Let a (e t v a) (e t (Suc v) a)
-  | LetBang [(Fin v, a)] a (e t v a) (e t (Suc v) a)
+  | Let a (e t v a) (e t ('Suc v) a)
+  | LetBang [(Fin v, a)] a (e t v a) (e t ('Suc v) a)
   | Tuple (e t v a) (e t v a)
   | Struct [(FieldName, e t v a)]  -- unboxed record
   | If (e t v a) (e t v a) (e t v a)   -- technically no longer needed as () + () == Bool
-  | Case (e t v a) TagName (Likelihood, a, e t (Suc v) a) (Likelihood, a, e t (Suc v) a)
+  | Case (e t v a) TagName (Likelihood, a, e t ('Suc v) a) (Likelihood, a, e t ('Suc v) a)
   | Esac (e t v a)
-  | Split (a, a) (e t v a) (e t (Suc (Suc v)) a)
+  | Split (a, a) (e t v a) (e t ('Suc ('Suc v)) a)
   | Member (e t v a) FieldIndex
-  | Take (a, a) (e t v a) FieldIndex (e t (Suc (Suc v)) a)
+  | Take (a, a) (e t v a) FieldIndex (e t ('Suc ('Suc v)) a)
   | Put (e t v a) FieldIndex (e t v a)
   | Promote (Type t) (e t v a)
-deriving instance (Show a, Show (e t v a), Show (e t (Suc (Suc v)) a), Show (e t (Suc v) a)) => Show (Expr t v a e)
+deriving instance (Show a, Show (e t v a), Show (e t ('Suc ('Suc v)) a), Show (e t ('Suc v) a)) => Show (Expr t v a e)
   -- constraint no smaller than header, thus UndecidableInstances
 
 data UntypedExpr t v a = E (Expr t v a UntypedExpr) deriving (Show)
@@ -133,13 +133,13 @@ instance Monoid Attr where
   (Attr a1 a2) `mappend` (Attr a1' a2') = Attr (a1 || a1') (a2 || a2')
 
 data Definition e a
-  = forall t. FunDef  Attr FunName (Vec t (TyVarName, Kind)) (Type t) (Type t) (e t (Suc Zero) a)
+  = forall t. FunDef  Attr FunName (Vec t (TyVarName, Kind)) (Type t) (Type t) (e t ('Suc 'Zero) a)
   | forall t. AbsDecl Attr FunName (Vec t (TyVarName, Kind)) (Type t) (Type t)
   | forall t. TypeDef TypeName (Vec t TyVarName) (Maybe (Type t))
 deriving instance Show a => Show (Definition TypedExpr a)
 deriving instance Show a => Show (Definition UntypedExpr a)
 
-type SFConst e = (VarName, e Zero Zero VarName)
+type SFConst e = (VarName, e 'Zero 'Zero VarName)
 
 getDefinitionId :: Definition e a -> String
 getDefinitionId (FunDef  _ fn _ _ _ _) = fn
@@ -256,7 +256,7 @@ untypeD (FunDef  attr fn ts ti to e) = FunDef  attr fn ts ti to (untypeE e)
 untypeD (AbsDecl attr fn ts ti to  ) = AbsDecl attr fn ts ti to
 untypeD (TypeDef tn ts mt) = TypeDef tn ts mt
 
-instance (Functor (e t v), Functor (e t (Suc v)), Functor (e t (Suc (Suc v)))) => Functor (Flip (Expr t v) e) where
+instance (Functor (e t v), Functor (e t ('Suc v)), Functor (e t ('Suc ('Suc v)))) => Functor (Flip (Expr t v) e) where
   fmap f (Flip (Variable v)         ) = Flip $ Variable (second f v)
   fmap f (Flip (Fun fn tys nt)      ) = Flip $ Fun fn tys nt
   fmap f (Flip (Op opr es)          ) = Flip $ Op opr (map (fmap f) es)
@@ -430,7 +430,7 @@ tcConsts ((v,e):ds) reader =
 -- XXX |     v1 = TyVar (FSuc FZero)
 -- XXX |     array = AbstractType "Array" . (:[])
 
-withBinding :: Type t -> TC t (Suc v) x -> TC t v x
+withBinding :: Type t -> TC t ('Suc v) x -> TC t v x
 withBinding t a
   = TC $ do readers <- ask
             st      <- get

--- a/cogent/src/Cogent/TypeProofs.hs
+++ b/cogent/src/Cogent/TypeProofs.hs
@@ -231,7 +231,9 @@ funDefEnv' fs = let binds = mkId $ intercalate " | " (fs ++ ["_ \\<Rightarrow> (
 (<\>) (Cons x xs) (Cons Nothing ys)  = Cons x       $ xs <\> ys
 (<\>) (Cons _ xs) (Cons (Just _) ys) = Cons Nothing $ xs <\> ys
 (<\>) Nil Nil = Nil
+#if __GLASGOW_HASKELL__ < 711
 (<\>) _ _ = error "TypeProofs: unreachable case in <\\>: vectors have mismatching lengths"
+#endif
 
 setAt :: [a] -> Int -> a -> [a]
 setAt (x:xs) 0 v = v:xs
@@ -445,7 +447,9 @@ treeSplit g x y = error $ "bad split: " ++ show (g, x, y)
 treeSplits :: Vec v (Maybe (Type t)) -> Vec v (Maybe (Type t)) -> Vec v (Maybe (Type t)) -> [Maybe TypeSplitKind]
 treeSplits (Cons g gs) (Cons x xs) (Cons y ys) = treeSplit g x y:treeSplits gs xs ys
 treeSplits Nil         Nil         Nil         = []
+#if __GLASGOW_HASKELL__ < 711
 treeSplits _ _ _ = __ghc_t4139 "TypeProofs.treeSplits"
+#endif
 
 treeBang :: Int -> [Int] -> [Maybe TypeSplitKind] -> [Maybe TypeSplitKind]
 treeBang i is (x:xs) | i `elem` is = Just TSK_NS:treeBang (i+1) is xs

--- a/cogent/src/Cogent/Vec.hs
+++ b/cogent/src/Cogent/Vec.hs
@@ -21,7 +21,10 @@
 
 module Cogent.Vec where
 
-import Cogent.Compiler (__impossible, __ghc_t4139)
+import Cogent.Compiler (__impossible)
+#if __GLASGOW_HASKELL__ < 711
+import Cogent.Compiler ( __ghc_t4139)
+#endif
 import Cogent.Util
 
 import Control.Applicative
@@ -41,25 +44,25 @@ data Exists :: (k -> *) -> * where
   ExI :: l v -> Exists l
 
 type family (:+:) (a :: Nat) (b :: Nat) :: Nat where
-   x :+: Zero = x
-   x :+: (Suc n) = Suc (x :+: n)
+   x :+: 'Zero = x
+   x :+: ('Suc n) = 'Suc (x :+: n)
 
 data (:=:) :: k -> k -> * where
   Refl :: a :=: a
 
-zeroPlusNEqualsN :: SNat n -> (Zero :+: n) :=: n
+zeroPlusNEqualsN :: SNat n -> ('Zero :+: n) :=: n
 zeroPlusNEqualsN SZero = Refl
 zeroPlusNEqualsN (SSuc n) | Refl <- zeroPlusNEqualsN n = Refl
 
-addSucLeft :: SNat v -> SNat n -> (Suc (v :+: n)) :=: (Suc v :+: n)
+addSucLeft :: SNat v -> SNat n -> ('Suc (v :+: n)) :=: ('Suc v :+: n)
 addSucLeft v SZero = Refl
 addSucLeft v (SSuc n) | Refl <- addSucLeft v n = Refl
 
-addSucLeft' :: SNat v -> SNat n -> (Suc (v :+: n)) :=: (Suc n :+: v)
+addSucLeft' :: SNat v -> SNat n -> ('Suc (v :+: n)) :=: ('Suc n :+: v)
 addSucLeft' SZero n | Refl <- zeroPlusNEqualsN n = Refl
 addSucLeft' (SSuc v) n | Refl <- addSucLeft v n, Refl <- addSucLeft' v n = Refl
 
-sucZeroIsSuc :: SNat n -> (Suc Zero :+: n) :=: (Suc n)
+sucZeroIsSuc :: SNat n -> ('Suc 'Zero :+: n) :=: ('Suc n)
 sucZeroIsSuc n | Refl <- sym (addSucLeft SZero n), Refl <- zeroPlusNEqualsN n = Refl
 
 sym :: a :=: b -> b :=: a
@@ -69,21 +72,21 @@ assoc :: SNat a -> SNat b -> SNat c -> (a :+: (b :+: c)) :=: ((a :+: b) :+: c)
 assoc a b SZero                          = Refl
 assoc a b (SSuc n) | Refl <- assoc a b n = Refl
 
-annoying :: SNat v -> SNat n -> SNat n1 -> Suc (v :+: n) :+: n1 :=: Suc (v :+: (n :+: n1))
+annoying :: SNat v -> SNat n -> SNat n1 -> 'Suc (v :+: n) :+: n1 :=: 'Suc (v :+: (n :+: n1))
 annoying v n n1 | Refl <- assoc v n n1
                 , Refl <- addSucLeft (sadd v n) n1
                 = Refl
 
-annoying' :: SNat v -> SNat n -> SNat n1 -> (Suc (Suc (v :+: n)) :+: n1) :=: (v :+: (Suc (Suc (n :+: n1))))
+annoying' :: SNat v -> SNat n -> SNat n1 -> ('Suc ('Suc (v :+: n)) :+: n1) :=: (v :+: ('Suc ('Suc (n :+: n1))))
 annoying' v n n1 | Refl <- assoc v n n1
                  , Refl <- addSucLeft (sadd v n) n1
                  , Refl <- addSucLeft (SSuc (sadd v n)) n1
                  = Refl
 
-withAssocSS :: SNat v -> SNat n -> SNat n1 -> ((Suc (Suc (v :+: n)) :+: n1) :=: (v :+: (Suc (Suc (n :+: n1)))) -> p) -> p
+withAssocSS :: SNat v -> SNat n -> SNat n1 -> (('Suc ('Suc (v :+: n)) :+: n1) :=: (v :+: ('Suc ('Suc (n :+: n1)))) -> p) -> p
 withAssocSS a b c = ($ annoying' a b c)
 
-withAssocS :: SNat v -> SNat n -> SNat n1 -> (Suc (v :+: n) :+: n1 :=: Suc (v :+: (n :+: n1)) -> p) -> p
+withAssocS :: SNat v -> SNat n -> SNat n1 -> ('Suc (v :+: n) :+: n1 :=: 'Suc (v :+: (n :+: n1)) -> p) -> p
 withAssocS v n n1 = ($ annoying v n n1)
 
 withAssoc :: SNat v -> SNat n -> SNat n1 -> ((v :+: n) :+: n1 :=: (v :+: (n :+: n1)) -> p) -> p
@@ -96,8 +99,8 @@ SSuc n =? SSuc m | Just Refl <- n =? m = Just Refl
 _ =? _ = Nothing
 
 data SNat :: Nat -> * where
-  SZero :: SNat Zero
-  SSuc :: SNat n -> SNat (Suc n)
+  SZero :: SNat 'Zero
+  SSuc :: SNat n -> SNat ('Suc n)
 
 deriving instance Show (SNat n)
 
@@ -109,8 +112,8 @@ instance L.Pretty (SNat n) where
   pretty = L.dullred . L.string . ('S':) . show . toInt
 
 data Fin :: Nat -> * where
-  FZero :: Fin (Suc n)
-  FSuc  :: Fin n -> Fin (Suc n)
+  FZero :: Fin ('Suc n)
+  FSuc  :: Fin n -> Fin ('Suc n)
 
 deriving instance Eq   (Fin n)
 deriving instance Show (Fin n)
@@ -125,8 +128,8 @@ finInt FZero = 0
 finInt (FSuc f) = finInt f + 1
 
 data Vec :: Nat -> * -> * where
-  Nil :: Vec Zero a
-  Cons :: a -> Vec n a -> Vec (Suc n) a
+  Nil :: Vec 'Zero a
+  Cons :: a -> Vec n a -> Vec ('Suc n) a
 
 deriving instance Show a => Show (Vec n a)
 deriving instance Eq a => Eq (Vec n a)
@@ -175,10 +178,10 @@ cvtToList :: Vec n a -> [a]
 cvtToList Nil = []
 cvtToList (Cons a v) = a:cvtToList v
 
-head :: Vec (Suc a) t -> t
+head :: Vec ('Suc a) t -> t
 head (Cons x xs) = x
 
-tail :: Vec (Suc a) t -> Vec a t
+tail :: Vec ('Suc a) t -> Vec a t
 tail (Cons x xs) = xs
 
 repeat :: SNat v -> a -> Vec v a
@@ -188,24 +191,38 @@ repeat (SSuc v) x = Cons x $ repeat v x
 splitAt :: SNat n -> Vec (v :+: n) a -> (Vec n a, Vec v a)
 splitAt SZero x = (Nil, x)
 splitAt (SSuc n) (Cons x xs) = let (a, b) = splitAt n xs in (Cons x a, b)
+#if __GLASGOW_HASKELL__ < 711
 splitAt _ _ = __ghc_t4139 "splitAt"
+#endif
 
-at :: Vec a t -> Fin a -> t
+at :: Vec ( a) t -> Fin ( a) -> t
+#if __GLASGOW_HASKELL__ > 711
+at Nil _ = error "impossible branch in at in Vec.HS"
+#endif
 at (Cons x xs) FZero    = x
 at (Cons x xs) (FSuc s) = at xs s
+#if __GLASGOW_HASKELL__ < 711
 at _ _ = __ghc_t4139 "at"
+#endif
 
 atList :: [t] -> Fin a -> t
 atList [] _ = __impossible "atList"
 atList (x:xs) FZero = x
 atList (x:xs) (FSuc s) = atList xs s
 
-update :: Vec a t -> Fin a -> t -> Vec a t
+update :: Vec a t -> Fin  a -> t -> Vec  a t
+#if __GLASGOW_HASKELL__ > 711
+update Nil _ _ = Nil
+#endif
 update (Cons _ xs) FZero    x' = Cons x' xs
 update (Cons x xs) (FSuc s) x' = Cons x (update xs s x')
+#if __GLASGOW_HASKELL__ < 711
 update _ _ _ = __ghc_t4139 "update"
+#endif
 
-modifyAt :: Fin a -> (t -> t) -> Vec a t -> Vec a t
+--modifyAt :: Fin ('Suc a) -> (t -> t) -> Vec ( a) t -> Vec ( a) t
+--modifyAt _empty _f Nil = Nil
+modifyAt :: Fin a -> (t -> t) -> Vec ( a) t -> Vec ( a) t
 modifyAt l f v = update v l (f (v `at` l))
 
 findIx :: (Eq t) => t -> Vec a t -> Maybe (Fin a)
@@ -218,8 +235,9 @@ allFins (SSuc n) = FZero `Cons` (FSuc <$> allFins n)
 zipWith :: (a -> b -> c) -> Vec n a -> Vec n b -> Vec n c
 zipWith f Nil Nil = Nil
 zipWith f (Cons x xs) (Cons y ys) = Cons (f x y) (zipWith f xs ys)
+#if __GLASGOW_HASKELL__ < 711
 zipWith _ _ _ = __ghc_t4139 "zipWith"
-
+#endif
 zip :: Vec n a -> Vec n b -> Vec n (a,b)
 zip = zipWith (,)
 
@@ -231,7 +249,7 @@ toInt :: SNat v -> Int
 toInt SZero = 0
 toInt (SSuc n) = 1 + toInt n
 
-widen :: Fin n -> Fin (Suc n)
+widen :: Fin n -> Fin ('Suc n)
 widen FZero = FZero
 widen (FSuc n) = FSuc (widen n)
 
@@ -245,11 +263,11 @@ upshift n (SSuc m) = FSuc (upshift n m)
 
 -- liftIdx idx var means:
 --   if idx <= var, var -> var + 1; otherwise intact
-liftIdx :: Fin (Suc n) -> Fin n -> Fin (Suc n)
+liftIdx :: Fin ('Suc n) -> Fin n -> Fin ('Suc n)
 liftIdx FZero v = FSuc v
 liftIdx (FSuc i) FZero = FZero
 liftIdx (FSuc i) (FSuc v) = FSuc $ liftIdx i v
 
-maxFin :: SNat n -> Fin (Suc n)
+maxFin :: SNat n -> Fin ('Suc n)
 maxFin SZero = FZero
 maxFin (SSuc n) = FSuc $ maxFin n

--- a/cogent/src/Data/Monoid/Cancellative.hs
+++ b/cogent/src/Data/Monoid/Cancellative.hs
@@ -1,0 +1,629 @@
+{-
+    Copyright 2013-2015 Mario Blazevic
+
+    License: BSD3 (see BSD3-LICENSE.txt file)
+-}
+
+-- | This module defines the 'Monoid' => 'ReductiveMonoid' => ('CancellativeMonoid', 'GCDMonoid') class hierarchy.
+--
+-- The 'ReductiveMonoid' class introduces operation '</>' which is the inverse of '<>'. For the 'Sum' monoid, this
+-- operation is subtraction; for 'Product' it is division and for 'Set' it's the set difference. A 'ReductiveMonoid' is
+-- not a full group because '</>' may return 'Nothing'.
+--
+-- The 'CancellativeMonoid' subclass does not add any operation but it provides the additional guarantee that '<>' can
+-- always be undone with '</>'. Thus 'Sum' is a 'CancellativeMonoid' but 'Product' is not because @(0*n)/0@ is not
+-- defined.
+--
+-- The 'GCDMonoid' subclass adds the 'gcd' operation which takes two monoidal arguments and finds their greatest common
+-- divisor, or (more generally) the greatest monoid that can be extracted with the '</>' operation from both.
+--
+-- All monoid subclasses listed above are for Abelian, /i.e./, commutative or symmetric monoids. Since most practical
+-- monoids in Haskell are not Abelian, each of the these classes has two symmetric superclasses:
+--
+-- * 'LeftReductiveMonoid'
+--
+-- * 'LeftCancellativeMonoid'
+--
+-- * 'LeftGCDMonoid'
+--
+-- * 'RightReductiveMonoid'
+--
+-- * 'RightCancellativeMonoid'
+--
+-- * 'RightGCDMonoid'
+
+{-# LANGUAGE Haskell2010, Trustworthy #-}
+
+module Data.Monoid.Cancellative (
+   -- * Symmetric, commutative monoid classes
+   CommutativeMonoid, ReductiveMonoid(..), CancellativeMonoid, GCDMonoid(..),
+   -- * Asymmetric monoid classes
+   LeftReductiveMonoid(..), RightReductiveMonoid(..),
+   LeftCancellativeMonoid, RightCancellativeMonoid,
+   LeftGCDMonoid(..), RightGCDMonoid(..)
+   )
+where
+
+import qualified Prelude
+
+import Data.Monoid -- (Monoid, Dual(..), Sum(..), Product(..))
+import qualified Data.List as List
+import Data.Maybe (isJust)
+import qualified Data.ByteString as ByteString
+import qualified Data.ByteString.Unsafe as ByteString
+import qualified Data.ByteString.Lazy as LazyByteString
+import qualified Data.Text as Text
+import qualified Data.Text.Lazy as LazyText
+import qualified Data.IntMap as IntMap
+import qualified Data.IntSet as IntSet
+import qualified Data.Map as Map
+import qualified Data.Sequence as Sequence
+import qualified Data.Set as Set
+import Data.Sequence (ViewL((:<)), ViewR((:>)), (<|), (|>))
+import qualified Data.Vector as Vector
+
+import Prelude hiding (gcd)
+
+-- | Class of all Abelian ({i.e.}, commutative) monoids that satisfy the commutativity property:
+--
+-- > a <> b == b <> a
+class Monoid m => CommutativeMonoid m
+
+-- | Class of Abelian monoids with a partial inverse for the Monoid '<>' operation. The inverse operation '</>' must
+-- satisfy the following laws:
+--
+-- > maybe a (b <>) (a </> b) == a
+-- > maybe a (<> b) (a </> b) == a
+class (CommutativeMonoid m, LeftReductiveMonoid m, RightReductiveMonoid m) => ReductiveMonoid m where
+   (</>) :: m -> m -> Maybe m
+
+infix 5 </>
+
+-- | Subclass of 'ReductiveMonoid' where '</>' is a complete inverse of the Monoid '<>' operation. The class instances
+-- must satisfy the following additional laws:
+--
+-- > (a <> b) </> a == Just b
+-- > (a <> b) </> b == Just a
+class (LeftCancellativeMonoid m, RightCancellativeMonoid m, ReductiveMonoid m) => CancellativeMonoid m
+
+-- | Class of Abelian monoids that allow the greatest common denominator to be found for any two given values. The
+-- operations must satisfy the following laws:
+--
+-- > gcd a b == commonPrefix a b == commonSuffix a b
+-- > Just a' = a </> p && Just b' = b </> p
+-- >    where p = gcd a b
+--
+-- If a 'GCDMonoid' happens to also be a 'CancellativeMonoid', it should additionally satisfy the following laws:
+--
+-- > gcd (a <> b) (a <> c) == a <> gcd b c
+-- > gcd (a <> c) (b <> c) == gcd a b <> c
+class (ReductiveMonoid m, LeftGCDMonoid m, RightGCDMonoid m) => GCDMonoid m where
+   gcd :: m -> m -> m
+
+-- | Class of monoids with a left inverse of 'Data.Monoid.mappend', satisfying the following law:
+--
+-- > isPrefixOf a b == isJust (stripPrefix a b)
+-- > maybe b (a <>) (stripPrefix a b) == b
+-- > a `isPrefixOf` (a <> b)
+--
+-- | Every instance definition has to implement at least the 'stripPrefix' method. Its complexity should be no worse
+-- than linear in the length of the prefix argument.
+class Monoid m => LeftReductiveMonoid m where
+   isPrefixOf :: m -> m -> Bool
+   stripPrefix :: m -> m -> Maybe m
+
+   isPrefixOf a b = isJust (stripPrefix a b)
+   {-# MINIMAL stripPrefix #-}
+
+-- | Class of monoids with a right inverse of 'Data.Monoid.mappend', satisfying the following law:
+--
+-- > isSuffixOf a b == isJust (stripSuffix a b)
+-- > maybe b (<> a) (stripSuffix a b) == b
+-- > b `isSuffixOf` (a <> b)
+--
+-- | Every instance definition has to implement at least the 'stripSuffix' method. Its complexity should be no worse
+-- than linear in the length of the suffix argument.
+class Monoid m => RightReductiveMonoid m where
+   isSuffixOf :: m -> m -> Bool
+   stripSuffix :: m -> m -> Maybe m
+
+   isSuffixOf a b = isJust (stripSuffix a b)
+   {-# MINIMAL stripSuffix #-}
+
+-- | Subclass of 'LeftReductiveMonoid' where 'stripPrefix' is a complete inverse of '<>', satisfying the following
+-- additional law:
+--
+-- > stripPrefix a (a <> b) == Just b
+class LeftReductiveMonoid m => LeftCancellativeMonoid m
+
+-- | Subclass of 'LeftReductiveMonoid' where 'stripPrefix' is a complete inverse of '<>', satisfying the following
+-- additional law:
+--
+-- > stripSuffix b (a <> b) == Just a
+class RightReductiveMonoid m => RightCancellativeMonoid m
+
+-- | Class of monoids capable of finding the equivalent of greatest common divisor on the left side of two monoidal
+-- values. The methods' complexity should be no worse than linear in the length of the common prefix. The following laws
+-- must be respected:
+--
+-- > stripCommonPrefix a b == (p, a', b')
+-- >    where p = commonPrefix a b
+-- >          Just a' = stripPrefix p a
+-- >          Just b' = stripPrefix p b
+-- > p == commonPrefix a b && p <> a' == a && p <> b' == b
+-- >    where (p, a', b') = stripCommonPrefix a b
+class LeftReductiveMonoid m => LeftGCDMonoid m where
+   commonPrefix :: m -> m -> m
+   stripCommonPrefix :: m -> m -> (m, m, m)
+
+   commonPrefix x y = p
+      where (p, _, _) = stripCommonPrefix x y
+   stripCommonPrefix x y = (p, x', y')
+      where p = commonPrefix x y
+            Just x' = stripPrefix p x
+            Just y' = stripPrefix p y
+   {-# MINIMAL commonPrefix | stripCommonPrefix #-}
+
+-- | Class of monoids capable of finding the equivalent of greatest common divisor on the right side of two monoidal
+-- values. The methods' complexity must be no worse than linear in the length of the common suffix. The following laws
+-- must be respected:
+--
+-- > stripCommonSuffix a b == (a', b', s)
+-- >    where s = commonSuffix a b
+-- >          Just a' = stripSuffix p a
+-- >          Just b' = stripSuffix p b
+-- > s == commonSuffix a b && a' <> s == a && b' <> s == b
+-- >    where (a', b', s) = stripCommonSuffix a b
+class RightReductiveMonoid m => RightGCDMonoid m where
+   commonSuffix :: m -> m -> m
+   stripCommonSuffix :: m -> m -> (m, m, m)
+
+   commonSuffix x y = s
+      where (_, _, s) = stripCommonSuffix x y
+   stripCommonSuffix x y = (x', y', s)
+      where s = commonSuffix x y
+            Just x' = stripSuffix s x
+            Just y' = stripSuffix s y
+   {-# MINIMAL commonSuffix | stripCommonSuffix #-}
+
+-- Unit instances
+
+instance CommutativeMonoid ()
+
+instance ReductiveMonoid () where
+   () </> () = Just ()
+
+instance CancellativeMonoid ()
+
+instance GCDMonoid () where
+   gcd () () = ()
+
+instance LeftReductiveMonoid () where
+   stripPrefix () () = Just ()
+
+instance RightReductiveMonoid () where
+   stripSuffix () () = Just ()
+
+instance LeftCancellativeMonoid ()
+
+instance RightCancellativeMonoid ()
+
+instance LeftGCDMonoid () where
+   commonPrefix () () = ()
+
+instance RightGCDMonoid () where
+   commonSuffix () () = ()
+
+-- Dual instances
+
+instance CommutativeMonoid a => CommutativeMonoid (Dual a)
+
+instance ReductiveMonoid a => ReductiveMonoid (Dual a) where
+   Dual a </> Dual b = fmap Dual (a </> b)
+
+instance CancellativeMonoid a => CancellativeMonoid (Dual a)
+
+instance GCDMonoid a => GCDMonoid (Dual a) where
+   gcd (Dual a) (Dual b) = Dual (gcd a b)
+
+instance LeftReductiveMonoid a => RightReductiveMonoid (Dual a) where
+   stripSuffix (Dual a) (Dual b) = fmap Dual (stripPrefix a b)
+   Dual a `isSuffixOf` Dual b = a `isPrefixOf` b
+
+instance RightReductiveMonoid a => LeftReductiveMonoid (Dual a) where
+   stripPrefix (Dual a) (Dual b) = fmap Dual (stripSuffix a b)
+   Dual a `isPrefixOf` Dual b = a `isSuffixOf` b
+
+instance LeftCancellativeMonoid a => RightCancellativeMonoid (Dual a)
+
+instance RightCancellativeMonoid a => LeftCancellativeMonoid (Dual a)
+
+instance LeftGCDMonoid a => RightGCDMonoid (Dual a) where
+   commonSuffix (Dual a) (Dual b) = Dual (commonPrefix a b)
+
+instance RightGCDMonoid a => LeftGCDMonoid (Dual a) where
+   commonPrefix (Dual a) (Dual b) = Dual (commonSuffix a b)
+
+-- Sum instances
+
+instance Num a => CommutativeMonoid (Sum a)
+
+instance Integral a => ReductiveMonoid (Sum a) where
+   Sum a </> Sum b = Just $ Sum (a - b)
+
+instance Integral a => CancellativeMonoid (Sum a)
+
+instance (Integral a, Ord a) => GCDMonoid (Sum a) where
+   gcd (Sum a) (Sum b) = Sum (min a b)
+
+instance Integral a => LeftReductiveMonoid (Sum a) where
+   stripPrefix a b = b </> a
+
+instance Integral a => RightReductiveMonoid (Sum a) where
+   stripSuffix a b = b </> a
+
+instance Integral a => LeftCancellativeMonoid (Sum a)
+
+instance Integral a => RightCancellativeMonoid (Sum a)
+
+instance (Integral a, Ord a) => LeftGCDMonoid (Sum a) where
+   commonPrefix a b = gcd a b
+
+instance (Integral a, Ord a) => RightGCDMonoid (Sum a) where
+   commonSuffix a b = gcd a b
+
+-- Product instances
+
+instance Num a => CommutativeMonoid (Product a)
+
+instance Integral a => ReductiveMonoid (Product a) where
+   Product 0 </> Product 0 = Just (Product 0)
+   Product _ </> Product 0 = Nothing
+   Product a </> Product b = if remainder == 0 then Just (Product quotient) else Nothing
+      where (quotient, remainder) = quotRem a b
+
+instance Integral a => GCDMonoid (Product a) where
+   gcd (Product a) (Product b) = Product (Prelude.gcd a b)
+
+instance Integral a => LeftReductiveMonoid (Product a) where
+   stripPrefix a b = b </> a
+
+instance Integral a => RightReductiveMonoid (Product a) where
+   stripSuffix a b = b </> a
+
+instance Integral a => LeftGCDMonoid (Product a) where
+   commonPrefix a b = gcd a b
+
+instance Integral a => RightGCDMonoid (Product a) where
+   commonSuffix a b = gcd a b
+
+-- Pair instances
+
+instance (CommutativeMonoid a, CommutativeMonoid b) => CommutativeMonoid (a, b)
+
+instance (ReductiveMonoid a, ReductiveMonoid b) => ReductiveMonoid (a, b) where
+   (a, b) </> (c, d) = case (a </> c, b </> d)
+                       of (Just a', Just b') -> Just (a', b')
+                          _ -> Nothing
+
+instance (CancellativeMonoid a, CancellativeMonoid b) => CancellativeMonoid (a, b)
+
+instance (GCDMonoid a, GCDMonoid b) => GCDMonoid (a, b) where
+   gcd (a, b) (c, d) = (gcd a c, gcd b d)
+
+instance (LeftReductiveMonoid a, LeftReductiveMonoid b) => LeftReductiveMonoid (a, b) where
+   stripPrefix (a, b) (c, d) = case (stripPrefix a c, stripPrefix b d)
+                               of (Just a', Just b') -> Just (a', b')
+                                  _ -> Nothing
+   isPrefixOf (a, b) (c, d) = isPrefixOf a c && isPrefixOf b d
+
+instance (RightReductiveMonoid a, RightReductiveMonoid b) => RightReductiveMonoid (a, b) where
+   stripSuffix (a, b) (c, d) = case (stripSuffix a c, stripSuffix b d)
+                               of (Just a', Just b') -> Just (a', b')
+                                  _ -> Nothing
+   isSuffixOf (a, b) (c, d) = isSuffixOf a c && isSuffixOf b d
+
+instance (LeftCancellativeMonoid a, LeftCancellativeMonoid b) => LeftCancellativeMonoid (a, b)
+
+instance (RightCancellativeMonoid a, RightCancellativeMonoid b) => RightCancellativeMonoid (a, b)
+
+instance (LeftGCDMonoid a, LeftGCDMonoid b) => LeftGCDMonoid (a, b) where
+   commonPrefix (a, b) (c, d) = (commonPrefix a c, commonPrefix b d)
+
+instance (RightGCDMonoid a, RightGCDMonoid b) => RightGCDMonoid (a, b) where
+   commonSuffix (a, b) (c, d) = (commonSuffix a c, commonSuffix b d)
+
+-- Maybe instances
+
+instance LeftReductiveMonoid x => LeftReductiveMonoid (Maybe x) where
+   stripPrefix Nothing y = Just y
+   stripPrefix Just{} Nothing = Nothing
+   stripPrefix (Just x) (Just y) = fmap Just $ stripPrefix x y
+
+instance LeftGCDMonoid x => LeftGCDMonoid (Maybe x) where
+   commonPrefix (Just x) (Just y) = Just (commonPrefix x y)
+   commonPrefix _ _ = Nothing
+
+   stripCommonPrefix (Just x) (Just y) = (Just p, Just x', Just y')
+      where (p, x', y') = stripCommonPrefix x y
+   stripCommonPrefix x y = (Nothing, x, y)
+
+instance RightReductiveMonoid x => RightReductiveMonoid (Maybe x) where
+   stripSuffix Nothing y = Just y
+   stripSuffix Just{} Nothing = Nothing
+   stripSuffix (Just x) (Just y) = fmap Just $ stripSuffix x y
+
+instance RightGCDMonoid x => RightGCDMonoid (Maybe x) where
+   commonSuffix (Just x) (Just y) = Just (commonSuffix x y)
+   commonSuffix _ _ = Nothing
+
+   stripCommonSuffix (Just x) (Just y) = (Just x', Just y', Just s)
+      where (x', y', s) = stripCommonSuffix x y
+   stripCommonSuffix x y = (x, y, Nothing)
+
+-- Set instances
+
+instance Ord a => CommutativeMonoid (Set.Set a)
+
+instance Ord a => LeftReductiveMonoid (Set.Set a) where
+   isPrefixOf = Set.isSubsetOf
+   stripPrefix a b = b </> a
+
+instance Ord a => RightReductiveMonoid (Set.Set a) where
+   isSuffixOf = Set.isSubsetOf
+   stripSuffix a b = b </> a
+
+instance Ord a => ReductiveMonoid (Set.Set a) where
+   a </> b | Set.isSubsetOf b a = Just (a Set.\\ b)
+           | otherwise = Nothing
+
+instance Ord a => LeftGCDMonoid (Set.Set a) where
+   commonPrefix = Set.intersection
+
+instance Ord a => RightGCDMonoid (Set.Set a) where
+   commonSuffix = Set.intersection
+
+instance Ord a => GCDMonoid (Set.Set a) where
+   gcd = Set.intersection
+
+-- IntSet instances
+
+instance CommutativeMonoid IntSet.IntSet
+
+instance LeftReductiveMonoid IntSet.IntSet where
+   isPrefixOf = IntSet.isSubsetOf
+   stripPrefix a b = b </> a
+
+instance RightReductiveMonoid IntSet.IntSet where
+   isSuffixOf = IntSet.isSubsetOf
+   stripSuffix a b = b </> a
+
+instance ReductiveMonoid IntSet.IntSet where
+   a </> b | IntSet.isSubsetOf b a = Just (a IntSet.\\ b)
+           | otherwise = Nothing
+
+instance LeftGCDMonoid IntSet.IntSet where
+   commonPrefix = IntSet.intersection
+
+instance RightGCDMonoid IntSet.IntSet where
+   commonSuffix = IntSet.intersection
+
+instance GCDMonoid IntSet.IntSet where
+   gcd = IntSet.intersection
+
+-- Map instances
+
+instance Ord k => LeftReductiveMonoid (Map.Map k a) where
+   isPrefixOf = Map.isSubmapOfBy (\_ _-> True)
+   stripPrefix a b | Map.isSubmapOfBy (\_ _-> True) a b = Just (b Map.\\ a)
+                   | otherwise = Nothing
+
+instance (Ord k, Eq a) => LeftGCDMonoid (Map.Map k a) where
+   commonPrefix = Map.mergeWithKey (\_ a b -> if a == b then Just a else Nothing) (const Map.empty) (const Map.empty)
+
+-- IntMap instances
+
+instance LeftReductiveMonoid (IntMap.IntMap a) where
+   isPrefixOf = IntMap.isSubmapOfBy (\_ _-> True)
+   stripPrefix a b | IntMap.isSubmapOfBy (\_ _-> True) a b = Just (b IntMap.\\ a)
+                   | otherwise = Nothing
+
+instance Eq a => LeftGCDMonoid (IntMap.IntMap a) where
+   commonPrefix = IntMap.mergeWithKey (\_ a b -> if a == b then Just a else Nothing)
+                                      (const IntMap.empty) (const IntMap.empty)
+
+-- List instances
+
+instance Eq x => LeftReductiveMonoid [x] where
+   stripPrefix = List.stripPrefix
+   isPrefixOf = List.isPrefixOf
+
+instance Eq x => LeftCancellativeMonoid [x]
+
+instance Eq x => LeftGCDMonoid [x] where
+   commonPrefix (x:xs) (y:ys) | x == y = x : commonPrefix xs ys
+   commonPrefix _ _ = []
+
+   stripCommonPrefix x0 y0 = strip' id x0 y0
+      where strip' f (x:xs) (y:ys) | x == y = strip' (f . (x :)) xs ys
+            strip' f x y = (f [], x, y)
+
+-- Seq instances
+
+instance Eq a => LeftReductiveMonoid (Sequence.Seq a) where
+   stripPrefix p s | p == s1 = Just s2
+                   | otherwise = Nothing
+      where (s1, s2) = Sequence.splitAt (Sequence.length p) s
+
+instance Eq a => RightReductiveMonoid (Sequence.Seq a) where
+   stripSuffix p s | p == s2 = Just s1
+                   | otherwise = Nothing
+      where (s1, s2) = Sequence.splitAt (Sequence.length s - Sequence.length p) s
+
+instance Eq a => LeftCancellativeMonoid (Sequence.Seq a)
+
+instance Eq a => RightCancellativeMonoid (Sequence.Seq a)
+
+instance Eq a => LeftGCDMonoid (Sequence.Seq a) where
+   stripCommonPrefix = findCommonPrefix Sequence.empty
+      where findCommonPrefix prefix a b = case (Sequence.viewl a, Sequence.viewl b)
+                                          of (a1:<a', b1:<b') | a1 == b1 -> findCommonPrefix (prefix |> a1) a' b'
+                                             _ -> (prefix, a, b)
+
+instance Eq a => RightGCDMonoid (Sequence.Seq a) where
+   stripCommonSuffix = findCommonSuffix Sequence.empty
+      where findCommonSuffix suffix a b = case (Sequence.viewr a, Sequence.viewr b)
+                                          of (a':>a1, b':>b1) | a1 == b1 -> findCommonSuffix (a1 <| suffix) a' b'
+                                             _ -> (a, b, suffix)
+
+-- Vector instances
+
+instance Eq a => LeftReductiveMonoid (Vector.Vector a) where
+   stripPrefix p l | prefixLength > Vector.length l = Nothing
+                    | otherwise = strip 0
+      where strip i | i == prefixLength = Just (Vector.drop prefixLength l)
+                    | l Vector.! i == p Vector.! i = strip (succ i)
+                    | otherwise = Nothing
+            prefixLength = Vector.length p
+   isPrefixOf p l | prefixLength > Vector.length l = False
+                  | otherwise = test 0
+      where test i | i == prefixLength = True
+                   | l Vector.! i == p Vector.! i = test (succ i)
+                   | otherwise = False
+            prefixLength = Vector.length p
+
+instance Eq a => RightReductiveMonoid (Vector.Vector a) where
+   stripSuffix s l | suffixLength > Vector.length l = Nothing
+                   | otherwise = strip (pred suffixLength)
+      where strip i | i == -1 = Just (Vector.take lengthDifference l)
+                    | l Vector.! (lengthDifference + i) == s Vector.! i = strip (pred i)
+                    | otherwise = Nothing
+            suffixLength = Vector.length s
+            lengthDifference = Vector.length l - suffixLength
+   isSuffixOf s l | suffixLength > Vector.length l = False
+                  | otherwise = test (pred suffixLength)
+      where test i | i == -1 = True
+                   | l Vector.! (lengthDifference + i) == s Vector.! i = test (pred i)
+                   | otherwise = False
+            suffixLength = Vector.length s
+            lengthDifference = Vector.length l - suffixLength
+
+instance Eq a => LeftCancellativeMonoid (Vector.Vector a)
+
+instance Eq a => RightCancellativeMonoid (Vector.Vector a)
+
+instance Eq a => LeftGCDMonoid (Vector.Vector a) where
+   stripCommonPrefix x y = (xp, xs, Vector.drop maxPrefixLength y)
+      where maxPrefixLength = prefixLength 0 (Vector.length x `min` Vector.length y)
+            prefixLength n len | n < len && x Vector.! n == y Vector.! n = prefixLength (succ n) len
+            prefixLength n _ = n
+            (xp, xs) = Vector.splitAt maxPrefixLength x
+
+instance Eq a => RightGCDMonoid (Vector.Vector a) where
+   stripCommonSuffix x y = findSuffix (Vector.length x - 1) (Vector.length y - 1)
+      where findSuffix m n | m >= 0 && n >= 0 && x Vector.! m == y Vector.! n =
+               findSuffix (pred m) (pred n)
+            findSuffix m n = (Vector.take (succ m) x, yp, ys)
+               where (yp, ys) = Vector.splitAt (succ n) y
+
+-- ByteString instances
+
+instance LeftReductiveMonoid ByteString.ByteString where
+   stripPrefix p l = if ByteString.isPrefixOf p l
+                     then Just (ByteString.unsafeDrop (ByteString.length p) l)
+                     else Nothing
+   isPrefixOf = ByteString.isPrefixOf
+
+instance RightReductiveMonoid ByteString.ByteString where
+   stripSuffix s l = if ByteString.isSuffixOf s l
+                     then Just (ByteString.unsafeTake (ByteString.length l - ByteString.length s) l)
+                     else Nothing
+   isSuffixOf = ByteString.isSuffixOf
+
+instance LeftCancellativeMonoid ByteString.ByteString
+
+instance RightCancellativeMonoid ByteString.ByteString
+
+instance LeftGCDMonoid ByteString.ByteString where
+   stripCommonPrefix x y = (xp, xs, ByteString.unsafeDrop maxPrefixLength y)
+      where maxPrefixLength = prefixLength 0 (ByteString.length x `min` ByteString.length y)
+            prefixLength n len | n < len,
+                                 ByteString.unsafeIndex x n == ByteString.unsafeIndex y n =
+                                    prefixLength (succ n) len
+                               | otherwise = n
+            (xp, xs) = ByteString.splitAt maxPrefixLength x
+
+instance RightGCDMonoid ByteString.ByteString where
+   stripCommonSuffix x y = findSuffix (ByteString.length x - 1) (ByteString.length y - 1)
+      where findSuffix m n | m >= 0, n >= 0,
+                             ByteString.unsafeIndex x m == ByteString.unsafeIndex y n =
+                                findSuffix (pred m) (pred n)
+                           | otherwise = let (yp, ys) = ByteString.splitAt (succ n) y
+                                         in (ByteString.unsafeTake (succ m) x, yp, ys)
+
+-- Lazy ByteString instances
+
+instance LeftReductiveMonoid LazyByteString.ByteString where
+   stripPrefix p l = if LazyByteString.isPrefixOf p l
+                     then Just (LazyByteString.drop (LazyByteString.length p) l)
+                     else Nothing
+   isPrefixOf = LazyByteString.isPrefixOf
+
+instance RightReductiveMonoid LazyByteString.ByteString where
+   stripSuffix s l = if LazyByteString.isSuffixOf s l
+                     then Just (LazyByteString.take (LazyByteString.length l - LazyByteString.length s) l)
+                     else Nothing
+   isSuffixOf = LazyByteString.isSuffixOf
+
+instance LeftCancellativeMonoid LazyByteString.ByteString
+
+instance RightCancellativeMonoid LazyByteString.ByteString
+
+instance LeftGCDMonoid LazyByteString.ByteString where
+   stripCommonPrefix x y = (xp, xs, LazyByteString.drop maxPrefixLength y)
+      where maxPrefixLength = prefixLength 0 (LazyByteString.length x `min` LazyByteString.length y)
+            prefixLength n len | n < len && LazyByteString.index x n == LazyByteString.index y n =
+               prefixLength (succ n) len
+            prefixLength n _ = n
+            (xp, xs) = LazyByteString.splitAt maxPrefixLength x
+
+instance RightGCDMonoid LazyByteString.ByteString where
+   stripCommonSuffix x y = findSuffix (LazyByteString.length x - 1) (LazyByteString.length y - 1)
+      where findSuffix m n | m >= 0 && n >= 0 && LazyByteString.index x m == LazyByteString.index y n =
+               findSuffix (pred m) (pred n)
+            findSuffix m n = (LazyByteString.take (succ m) x, yp, ys)
+               where (yp, ys) = LazyByteString.splitAt (succ n) y
+
+-- Text instances
+
+instance LeftReductiveMonoid Text.Text where
+   stripPrefix = Text.stripPrefix
+   isPrefixOf = Text.isPrefixOf
+
+instance RightReductiveMonoid Text.Text where
+   stripSuffix = Text.stripSuffix
+   isSuffixOf = Text.isSuffixOf
+
+instance LeftCancellativeMonoid Text.Text
+
+instance RightCancellativeMonoid Text.Text
+
+instance LeftGCDMonoid Text.Text where
+   stripCommonPrefix x y = maybe (Text.empty, x, y) id (Text.commonPrefixes x y)
+
+-- Lazy Text instances
+
+instance LeftReductiveMonoid LazyText.Text where
+   stripPrefix = LazyText.stripPrefix
+   isPrefixOf = LazyText.isPrefixOf
+
+instance RightReductiveMonoid LazyText.Text where
+   stripSuffix = LazyText.stripSuffix
+   isSuffixOf = LazyText.isSuffixOf
+
+instance LeftCancellativeMonoid LazyText.Text
+
+instance RightCancellativeMonoid LazyText.Text
+
+instance LeftGCDMonoid LazyText.Text where
+   stripCommonPrefix x y = maybe (LazyText.empty, x, y) id (LazyText.commonPrefixes x y)


### PR DESCRIPTION
This patch contains the following changes:
* Drop monoid-subclasses as a dependency because it is really broken in 8.0
  and has lots of orphans.
* Made a number of Fin types more accurate.
* Remove GHC < 8.0 conditional error branches that allegedly aren't needed in
  8.0.
* Fixed some goodly numer of Ticked Constructor warnings
* Trimmied trailing whitespace noise.