### PR TITLE
Rename cogent.h to cogent-defns.h

### DIFF
--- a/cogent/lib/cogent-defns.h
+++ b/cogent/lib/cogent-defns.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, NICTA
+ * Copyright 2017, NICTA
  *
  * This software may be distributed and modified according to the terms of
  * the GNU General Public License version 2. Note that NO WARRANTY is provided.
@@ -8,8 +8,8 @@
  * @TAG(NICTA_GPL)
  */
 
-#ifndef __COGENT_H__
-#define __COGENT_H__
+#ifndef __COGENT_DEFNS_H__
+#define __COGENT_DEFNS_H__
 
 #define likely(x)       __builtin_expect(!!(x), 1)
 #define unlikely(x)     __builtin_expect(!!(x), 0)
@@ -20,11 +20,11 @@ typedef unsigned int u32;
 typedef unsigned long long u64;
 
 typedef struct unit_t {
-  int dummy;
+        int dummy;
 } unit_t;
 
 typedef struct bool_t {
-  u8 boolean;
+        u8 boolean;
 } bool_t;
 
-#endif
+#endif  /* __COGENT_DEFNS_H__ */

--- a/cogent/scripts/cogent_validate.sh
+++ b/cogent/scripts/cogent_validate.sh
@@ -361,7 +361,7 @@ if [[ "$TESTSPEC" =~ '--gcc--' ]]; then
     mkdir -p "$abs" || exit
     echo -n "${outfile}.cogent: "
     total+=1
-    sed -i -r 's/^#include <cogent.h>/#include \"..\/lib\/cogent.h\"/' "$hfile"
+    sed -i -r 's/^#include <cogent-defns.h>/#include \"..\/lib\/cogent-defns.h\"/' "$hfile"
     sed -i -r "s|^#include <abstract/([^\.]*).h>|#include \"$abs/\1.h\"|g" "$hfile"
     for abstract_h in `egrep "^#include \"$abs\/([^\.]*).h\"" "$hfile" | \
                        sed -r "s|#include \"$abs/([^\.]*).h\"|\1|"`; do
@@ -491,7 +491,7 @@ if [[ "$TESTSPEC" =~ '--ee--' ]]; then
        mkdir -p "$abs" || exit
        echo -n "${outfile}.cogent: "
        cogent -A --fml-typing-tree --root-dir=../../ --dist-dir="$COUT" "$source" --proof-name="$ISABELLE_SESSION_NAME"
-       sed -i -r 's|^#include <cogent.h>|#include \"../tests/cogent.h\"|' "$hfile"
+       sed -i -r 's|^#include <cogent-defns.h>|#include \"../test/cogent.h\"|' "$hfile"
        sed -i -r "s|^#include <abstract/([^\.]*).h>|#include \"$abs/\1.h\"|g" "$hfile"
        for abstract_h in `egrep "^#include \"$abs\/([^\.]*).h\"" "$hfile" | \
                           sed -r "s|#include \"$abs/([^\.]*).h\"|\1|"`; do

--- a/cogent/src/Cogent/CodeGen.hs
+++ b/cogent/src/Cogent/CodeGen.hs
@@ -387,12 +387,12 @@ genEnum = do
              enumMembers = P.map (,Nothing) $ S.toList tags
          in return $ [CDecl $ CEnumDecl (Just tagsT) enumMembers, CDecl $ CTypeDecl (CEnum tagsT) [tagsT]]
 
--- NOTE: It's not used becuase it's defined in cogent.h / zilinc
+-- NOTE: It's not used becuase it's defined in cogent-defns.h / zilinc
 genBool :: Gen v [CExtDecl]
 genBool = pure [ CDecl $ CStructDecl boolT [(CogentPrim U8, Just boolField)]
                , CDecl $ CTypeDecl (CStruct boolT) [boolT]]
 
--- NOTE: It's not used becuase it's defined in cogent.h / zilinc
+-- NOTE: It's not used becuase it's defined in cogent-defns.h / zilinc
 genUnit :: Gen v [CExtDecl]
 genUnit = pure [ CDecl $ CStructDecl unitT [(CInt True CIntT, Just dummyField)]  -- NOTE: now the dummy field is an int for verification / zilinc
                , CDecl $ CTypeDecl (CStruct unitT) [unitT]]
@@ -1109,7 +1109,7 @@ gen hfn defs insts log =
       C.EscDef "" noLoc :
       C.EscDef ("#ifndef " ++ gn) noLoc :
       C.EscDef ("#define " ++ gn ++ "\n") noLoc :
-      C.EscDef ("#include <cogent.h>  /* FIXME: Change to or search for the proper path */\n") noLoc :
+      C.EscDef ("#include <cogent-defns.h>\n") noLoc :
       -- NOTE: These two lines are not useful because AlexH has the Python program to resolve names / zilinc
       -- concat (map cFunMacro (M.toList insts)) ++  -- macros for function names
       -- catMaybes (map cDispatchMacro stbns') ++    -- macros for dispatch functions

--- a/cogent/tests/cogent.h
+++ b/cogent/tests/cogent.h
@@ -8,6 +8,9 @@
  * @TAG(NICTA_GPL)
  */
 
-#include "../lib/cogent.h"
+/*
+  NOTE: Do not delete this file, it is needed for verification purposes.
+ */
+#include "../lib/cogent-defns.h"
 
 void dummyFunction (void) {return;}

--- a/impl/bilby/cogent/plat/verification/wrapper.ac
+++ b/impl/bilby/cogent/plat/verification/wrapper.ac
@@ -12,7 +12,7 @@
  * Template for verification build, with dummy type definitions.
  */
 
-#include <cogent.h>
+#include <cogent-defns.h>
 
 struct rbt_node {
     struct unit_t unit;

--- a/impl/ext2/cogent/plat/verification/wrapper.ac
+++ b/impl/ext2/cogent/plat/verification/wrapper.ac
@@ -12,7 +12,7 @@
  * Template for verification build, with dummy type definitions.
  */
 
-#include <cogent.h>
+#include <cogent-defns.h>
 
 typedef struct VfsInodeAbstract {
   int dummy;


### PR DESCRIPTION
`cogent-defns.h` is a much more appropriate name. Also remove the duplicate
`cogent.h` in `tests`.