### PR TITLE
Include the proper path for buffer.cogent.

### DIFF
--- a/cogent/cogent.cabal
+++ b/cogent/cogent.cabal
@@ -28,7 +28,7 @@ data-files:
 
 source-repository head
   type:     git
-  location: https://github.inside.nicta.com.au/ts-filesystems/bilby
+  location: https://github.com/NICTA/cogent/
 
 Library
   hs-source-dirs: src

--- a/impl/bilby/cogent/src/ubi.cogent
+++ b/impl/bilby/cogent/src/ubi.cogent
@@ -9,7 +9,7 @@
 --
 
 include <gum/common/common.cogent>
-include <gum/kernel/linux/buffer.cogent>
+include <gum/common/buffer.cogent>
 include "bilbyfs.cogent"
 
 type EbNum = U32


### PR DESCRIPTION
I had accidentally assumed that buffer.cogent was in `gum/kernel/linux`
instead of `gum/common`. This patch fixes that mistake.