### PR TITLE
[libgum] Some methods to access struct buffer_head

### DIFF
--- a/cogent/lib/c/linux/abstract-defns.h
+++ b/cogent/lib/c/linux/abstract-defns.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017, NICTA
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(NICTA_GPL)
+ */
+/*
+ * abstract-defns.h
+ * This file contains the abstract data type definitions that all linux kernel
+ * modules will need.
+ */
+
+#ifndef ABSTRACT_DEFNS_H_
+#define ABSTRACT_DEFNS_H_
+
+typedef int Int;
+typedef unsigned int UInt;
+typedef u8 * U8Ptr;
+
+typedef __le16 LE16;
+typedef __le32 LE32;
+typedef __le64 LE64;
+typedef __be16 BE16;
+typedef __be32 BE32;
+typedef __be64 BE64;
+
+typedef rwlock_t RWLock;
+typedef kuid_t KUID;
+typedef kgid_t KGID;
+typedef spinlock_t SpinLock;
+
+typedef struct rw_semaphore RWSemaphore;
+typedef struct mutex Mutex;
+typedef struct list_head ListHead;
+typedef struct quota DQuota;
+typedef struct buffer_head BufferHead;
+typedef struct buffer_head * BufferHeadPtr;
+typedef struct percpu_counter PerCPUCounter;
+typedef struct blockgroup_lock BlockGroupLock;
+typedef struct rb_root RBRoot;
+typedef struct mb_cache MBCache;
+typedef struct super_block VfsSuperBlock;
+typedef struct inode Inode;
+typedef struct dir_context DirContext;
+typedef struct page Page;
+typedef struct page PageBuffer;
+typedef struct address_space AddressSpace;
+
+typedef struct ubi_volume_desc UbiVolDesc;
+
+#endif  /* ABSTRACT_DEFNS_H_ */

--- a/cogent/lib/gum/anti/bufferhead.ac
+++ b/cogent/lib/gum/anti/bufferhead.ac
@@ -1,0 +1,264 @@
+/*
+ * Copyright 2017, NICTA
+ *
+ * This software may be distributed and modified according to the terms of
+ * the GNU General Public License version 2. Note that NO WARRANTY is provided.
+ * See "LICENSE_GPLv2.txt" for details.
+ *
+ * @TAG(NICTA_GPL)
+ */
+/*
+ * For documentation on these functions look in bufferhead.cogent
+ */
+
+$ty:(RR SysState BufferHead ()) buffer_head_new($ty:(SysState) st)
+{
+        $ty:(R BufferHead ()) success = { .Success = NULL, .tag = TAG_ENUM_Success };
+        $ty:(RR SysState BufferHead ()) ret = { .p1 = st, .p2 = success };
+
+        return ret;
+}
+
+$ty:(SysState) buffer_head_free($ty:((SysState, BufferHead)) args)
+{
+        brelse(args.p2);
+        return args.p1;
+}
+
+$ty:(SysState) buffer_head_forget($ty:((SysState, BufferHead)) args)
+{
+        bforget(args.p2);
+        return args.p1;
+}
+
+$ty:(U32) buffer_head_get_size($ty:(BufferHead!) bh)
+{
+        return bh->b_size;
+}
+
+$ty:(BufferHead) buffer_head_set_size($ty:((BufferHead, U32)) args)
+{
+        struct buffer_head *bh = args.p1;
+        bh->b_size = args.p2;
+
+        return args.p1;
+}
+
+$ty:(U64) buffer_head_get_blocknum($ty:(BufferHead!) bh)
+{
+        return bh->b_blocknr;
+}
+
+$ty:(RR (SysState, VfsSuperBlock, BufferHead) () ())buffer_head_read_block($ty:((#{st: SysState, sb: VfsSuperBlock,  bh: BufferHead, blknr: U64})) args)
+{
+        $ty:((SysState, VfsSuperBlock, BufferHead)) st_sb_bh_tuple = {.p1 = args.st, .p2 = args.sb, .p3 = args.bh};
+        $ty:(RR (SysState, BufferHead) () ()) ret = {.p1 = st_sb_bh_tuple};
+
+        if (ret.p1.p3 != NULL) {
+                /* existing buffer, map */
+                map_bh(ret.p1.p3, args.sb, (sector_t)args.blk);
+        } else {
+                /* new buffer, read */
+                ret.p1.p3 = sb_bread(args.sb, (sector_t)args.blk);
+        }
+
+        if (likely (ret.p1.p3 != NULL)) {
+                ret.p3.tag = TAG_ENUM_Success;
+        } else {
+                /* Reading block failed at block : args.blk */
+                ret.p3.tag = TAG_ENUM_Error;
+        }
+
+        return ret;
+
+}
+
+$ty:(BufferHead) buffer_head_boundary($ty:(BufferHead) bh)
+{
+        set_buffer_boundary(bh);
+        return buf;
+}
+
+$ty:((SysState, VfsSuperBlock)) buffer_head_readahead($ty:((SysState, VfsSuperBlock, U64)) args)
+{
+        $ty:((SysState, VfsSuperBlock)) ret = {.p1 = args.p1, .p2 = args.p2};
+        sb_breadahead(args.p2, args.p3);
+        return ret;
+}
+
+$ty:(SysState, BufferHead) buffer_head_sync_dirty($ty:(SysState, BufferHead) args)
+{
+        sync_dirty_buffer(args.p2);
+        return args;
+}
+
+$ty:((SysState, BufferHead)) buffer_head_mark_dirty($ty:((SysState, BufferHead)) args)
+{
+        mark_buffer_dirty(args.p2);
+        return args;
+}
+
+$ty:((SysState, BufferHead)) buffer_head_set_new($ty:((SysState, BufferHead)) args)
+{
+        set_buffer_new(args.p2);
+        return args;
+}
+
+$ty:((SysState, BufferHead)) buffer_head_set_uptodate($ty:((SysState, BufferHead)) args)
+{
+        set_buffer_uptodate(args.p2);
+        return args;
+}
+
+$ty:(Result (BufferHead, BufferHeadOffset) (BufferHead)) buffer_head_serialise_Ple32($ty:((BufferHead, BufferHeadOffset, U32)) args)
+{
+        $ty:(Result (BufferHead, BufferHeadOffset) (BufferHead)) ret;
+        $ty:(BufferHead) buf = args.p1;
+
+        if (unlikely(args.p2 >= BLOCK_SIZE)) {
+                ret.tag = TAG_ENUM_Error;
+                ret.Error = buf;
+        } else {
+                u32 raw = cpu_to_le32(args.p3);
+                u32* p = ((u32*)(buf->b_data + args.p2));
+
+                *p = raw;
+
+                ret.tag = TAG_ENUM_Success;
+                ret.Success.p1 = buf;
+                ret.Success.p2 = args.p2 + sizeof(u32);
+        }
+
+        return ret;
+}
+
+$ty:(Result (U32, BufferHeadOffset) ()) buffer_head_deserialise_Ple32($ty:((BufferHead!, BufferHeadOffset)) args)
+{
+        $ty:(Result (U32, BufferHeadOffset) ()) ret;
+        $ty:(BufferHead) buf = args.p1;
+
+
+        if (unlikely(args.p2 >= BLOCK_SIZE)) {
+                ret.tag = TAG_ENUM_Error;
+        } else {
+                u32 raw = *((u32*)(buf->b_data + args.p2));
+                u32 host = le32_to_cpu(raw);
+
+                ret.tag = TAG_ENUM_Success;
+                ret.Success.p1 = host;
+                ret.Success.p2 = args.p2 + sizeof(u32);
+        }
+
+        return ret;
+}
+
+$ty:(Result (BufferHead, BufferHeadOffset) (BufferHead)) buffer_head_serialise_Ple16($ty:((BufferHead, BufferHeadOffset, U16)) args)
+{
+        $ty:(Result (BufferHead, BufferHeadOffset) (BufferHead)) ret;
+        $ty:(BufferHead) buf = args.p1;
+
+        if (unlikely(args.p2 >= BLOCK_SIZE)) {
+                ret.tag = TAG_ENUM_Error;
+                ret.Error = buf;
+        } else {
+                u16 raw = cpu_to_le16(args.p3);
+                u16* p = ((u16*)(buf->b_data + args.p2));
+
+                *p = raw;
+
+                ret.tag = TAG_ENUM_Success;
+                ret.Success.p1 = buf;
+                ret.Success.p2 = args.p2 + sizeof(u16);
+        }
+
+        return ret;
+}
+
+$ty:(Result (U16, BufferHeadOffset) ()) buffer_head_deserialise_Ple16($ty:((BufferHead!, BufferHeadOffset)) args)
+{
+        $ty:(Result (U16, BufferHeadOffset) ()) ret;
+        $ty:(BufferHead) buf = args.p1;
+
+        if (unlikely(args.p2 >= BLOCK_SIZE)) {
+                ret.tag = TAG_ENUM_Error;
+        } else {
+                u16 raw = *((u16*)(buf->b_data + args.p2));
+                u16 host = le16_to_cpu(raw);
+
+                ret.tag = TAG_ENUM_Success;
+                ret.Success.p1 = host;
+                ret.Success.p2 = args.p2 + sizeof(u16);
+        }
+
+        return ret;
+}
+
+$ty:(Result (BufferHead, BufferHeadOffset) (BufferHead)) buffer_head_serialise_U8($ty:((BufferHead, BufferHeadOffset, U8)) args)
+{
+        $ty:(Result (BufferHead, BufferHeadOffset) (BufferHead)) ret;
+        $ty:(BufferHead) buf = args.p1;
+
+        /* TODO: Implement this */
+        return ret;
+}
+
+$ty:(Result (U8, BufferHeadOffset) ()) buffer_head_deserialise_U8($ty:((BufferHead!, BufferHeadOffset)) args)
+{
+        $ty:(Result (U8, BufferHeadOffset) ()) ret;
+        $ty:(BufferHead) buf = args.p1;
+
+        if (unlikely(args.p2 >= BLOCK_SIZE)) {
+                ret.tag = TAG_ENUM_Error;
+        } else {
+                u8 raw = *((u8*)(buf->b_data + args.p2));
+
+                ret.tag = TAG_ENUM_Success;
+                ret.Success.p1 = raw;
+                ret.Success.p2 = args.p2 + sizeof(u8);
+        }
+
+        return ret;
+}
+
+$ty:(U32) buffer_head_find($ty:((BufferHead!, U8, BufferHeadOffset, U32)) args)
+{
+        u32* start = (u32*)args.p1->b_data + args.p3;
+        return start - (u32*)memscan(start, args.p2, args.p4);
+}
+
+$ty:(BufferHead) buffer_head_memset($ty:((BufferHead, BufferHeadOffset, U32, U32)) args)
+{
+        memset(args.p1->b_data + args.p2, args.p3, args.p4);
+        return args.p1;
+}
+
+$ty:(BufferHeadOffset) buffer_head_find_next_zero_bit($ty:((BufferHead!, U32, BufferHeadOffset)) args)
+{
+        return find_next_zero_bit_le(args.p1->b_data, args.p2, args.p3);
+}
+
+/*
+  NOTE: In the following functions we return a negative number because the value
+  of a 1-bit signed number is either 0 or -1, so we negate the resultant 0 or 1
+  that the DSL expects.
+ */
+$ty:((BufferHead, Bool)) buffer_head_set_bit ($ty:((BufferHead, BufferHeadOffset)) args)
+{
+        $ty:((BufferHead, Bool)) ret = { .p1 = args.p1 };
+        ret.p2.boolean = -__test_and_set_bit_le(args.p2, args.p1->b_data);
+        return ret;
+}
+
+$ty:((BufferHead, Bool)) buffer_head_clear_bit ($ty:((BufferHead, BufferHeadOffset)) args) {
+        $ty:((BufferHead, Bool)) ret = { .p1 = args.p1 };
+
+        ret.p2.boolean =  -__test_and_clear_bit_le (args.p2, args.p1->b_data);
+        return ret;
+}
+
+$ty:(Bool) buffer_head_test_bit($ty:((BufferHead!, U32)) args)
+{
+        $ty:(Bool) ret;
+        ret.boolean = -test_bit_le(args.p2, args.p1->b_data);
+        return ret;
+}

--- a/cogent/lib/gum/anti/bufferhead.ac
+++ b/cogent/lib/gum/anti/bufferhead.ac
@@ -49,7 +49,7 @@ $ty:(U64) buffer_head_get_blocknum($ty:(BufferHead!) bh)
         return bh->b_blocknr;
 }
 
-$ty:(RR (SysState, VfsSuperBlock, BufferHead) () ())buffer_head_read_block($ty:((#{st: SysState, sb: VfsSuperBlock,  bh: BufferHead, blknr: U64})) args)
+$ty:(RR (SysState, VfsSuperBlock, BufferHead) () ()) buffer_head_read_block($ty:(#{st: SysState, sb: VfsSuperBlock, bh: BufferHead, blknr: U64}) args)
 {
         $ty:((SysState, VfsSuperBlock, BufferHead)) st_sb_bh_tuple = {.p1 = args.st, .p2 = args.sb, .p3 = args.bh};
         $ty:(RR (SysState, BufferHead) () ()) ret = {.p1 = st_sb_bh_tuple};

--- a/cogent/lib/gum/common/common.cogent
+++ b/cogent/lib/gum/common/common.cogent
@@ -1,5 +1,5 @@
 --
--- Copyright 2016, NICTA
+-- Copyright 2017, NICTA
 --
 -- This software may be distributed and modified according to the terms of
 -- the GNU General Public License version 2. Note that NO WARRANTY is provided.
@@ -21,6 +21,12 @@ type RR c a b = (c, <Success a | Error b>)
 type ErrCode = U32
 type WordArrayIndex = U32
 type ExState
+
+-- SysState is the state that we will be carrying around and used in all functions
+-- that modify an external state in the system. This will abstract away, from Cogent,
+-- all the side effects that are caused by IO or something similar.
+-- This is an abstract type and needs to be defined in the implementation.
+type SysState
 
 type ElemA a acc = #{elem: a, acc: acc}
 type ElemB a rbrk = #{elem:a, rbrk:rbrk}

--- a/cogent/lib/gum/kernel/linux/bufferhead.cogent
+++ b/cogent/lib/gum/kernel/linux/bufferhead.cogent
@@ -1,0 +1,195 @@
+--
+-- Copyright 2017, NICTA
+--
+-- This software may be distributed and modified according to the terms of
+-- the GNU General Public License version 2. Note that NO WARRANTY is provided.
+-- See "LICENSE_GPLv2.txt" for details.
+--
+-- @TAG(NICTA_GPL)
+--
+--
+-- These are wrapper functions for struct buffer_head in the linux kernel.
+--
+
+include "../../common/wordarray.cogent" -- wordarray.cogent includes common.cogent
+
+-- BufferHead is an abstract type that is defined typedef'ed to `struct buffer_head`
+-- on Linux.
+type BufferHead
+type BufferHeadOffset = U32
+
+-- buffer_head_new:
+--  Although we never 'create' a buffer, this just acts as a 'no-op'
+{-# cinline buffer_head_new #-}
+buffer_head_new: SysState -> RR SysState BufferHead ()
+
+-- buffer_head_free:
+--  This function calls brelse()
+{-# cinline buffer_head_free #-}
+buffer_head_free: (SysState, BufferHead) -> SysState
+
+-- buffer_head_forget:
+--  buffer_head_forget() is like buffer_head_free() except that it discards
+--  any potentially dirty data, as it calls bforget()
+{-# cinline buffer_head_forget #-}
+buffer_head_forget: (SysState, BufferHead) -> SysState
+
+-- buffer_head_get_size:
+--
+{-# cinline buffer_head_get_size #-}
+buffer_head_get_size: BufferHead! -> U32
+
+-- buffer_head_set_size:
+--
+{-# cinline buffer_head_set_size #-}
+buffer_head_set_size: (BufferHead, U32) -> BufferHead
+
+-- buffer_head_get_blocknum
+--
+{-# cinline buffer_head_get_blocknum #-}
+buffer_head_get_blocknum: BufferHead! -> U64
+
+-- buffer_head_read_block:
+--
+{-# cinline buffer_head_read_block #-}
+buffer_head_read_block: (#{st: SysState, sb: VfsSuperBlock, bh: BufferHead, blknr: U64}) -> RR (SysState, VfsSuperBlock, BufferHead) () ()
+
+-- buffer_head_boundary:
+--  sets that the block is followed by a discontiguity.
+--  This calls set_buffer_boundary(), A function that is defined in buffer_head.h
+--  in the Linux kernel using the macro BUFFER_FNS().
+{-# cinline buffer_head_boundary #-}
+buffer_head_boundary: BufferHead -> BufferHead
+
+-- buffer_head_readahead:
+--
+{-# cinline buffer_head_readahead #-}
+buffer_head_readahead: (SysState, VfsSuperBlock, U32) -> (SysState, VfsSuperBlock)
+
+-- buffer_head_sync_dirty:
+--  We need to have ref on the BufferHead
+{-# cinline buffer_head_sync_dirty #-}
+buffer_head_sync_dirty: (SysState, BufferHead) -> (SysState, BufferHead)
+
+-- buffer_head_mark_dirty:
+--
+{-# cinline buffer_head_mark_dirty #-}
+buffer_head_mark_dirty: (SysState, BufferHead) -> (SysState, BufferHead)
+
+-- buffer_head_set_new:
+--  This calls set_buffer_new(), A function that is defined in buffer_head.h
+--  in the Linux kernel using the macro BUFFER_FNS().
+{-# cinline buffer_head_set_new #-}
+buffer_head_set_new: (SysState, BufferHead) -> (SysState, BufferHead)
+
+-- buffer_head_set_uptodate:
+--  This calls set_buffer_uptodate(), A function that is defined in buffer_head.h
+--  in the Linux kernel using the macro BUFFER_FNS().
+{-# cinline buffer_head_set_uptodate #-}
+buffer_head_set_uptodate: (SysState, BufferHead) -> (SysState, BufferHead)
+
+
+
+--
+-- Serialisation and Deserialisation functions
+--
+
+-- buffer_head_serialise_Ple32_WordArray
+--
+buffer_head_serialise_Ple32_WordArray: WordArrayFoldF U32 (BufferHead, BufferHeadOffset) () (BufferHead, BufferHeadOffset)
+buffer_head_serialise_Ple32_WordArray #{elem, acc = (bh, idx), obsv} =
+  buffer_head_serialise_Ple32 (bh, idx, elem)
+  | Success (bh, idx') ->
+    Iterate (bh, idx')
+  | Error bh ->
+    Break (bh, idx)
+
+-- buffer_head_deserialise_Ple32_WordArray
+--
+buffer_head_deserialise_Ple32_WordArray: (#{elem: U32, acc: U32, obsv: BufferHead!}) -> LRR (U32, U32) ()
+buffer_head_deserialise_Ple32_WordArray (#{elem = old, acc = idx, obsv = bh}) =
+  buffer_head_deserialise_Ple32 (bh, idx)
+  | Success (elem, idx') ->
+    ((elem, idx'), Iterate ())
+  | Error () ->
+    ((old, idx), Break ())
+
+-- buffer_head_deserialise_U8_WordArray
+--
+buffer_head_deserialise_U8_WordArray: (#{elem: U8, acc: U32, obsv: BufferHead!}) -> LRR (U8, U32) ()
+buffer_head_deserialise_U8_WordArray (#{elem = old, acc = idx, obsv = bh}) =
+  buffer_head_deserialise_U8 (bh, idx)
+  | Success (elem, idx') ->
+    ((elem, idx'), Iterate ())
+  | Error () ->
+    ((old, idx), Break ())
+
+-- buffer_head_serialise_Ple32
+--
+{-# cinline buffer_head_serialise_Ple32 #-}
+buffer_head_serialise_Ple32: (BufferHead, BufferHeadOffset, U32) -> Result (BufferHead, BufferHeadOffset) (BufferHead)
+
+-- buffer_head_deserialise_Ple32
+--
+{-# cinline buffer_head_deserialise_Ple32 #-}
+buffer_head_deserialise_Ple32: (BufferHead!, BufferHeadOffset) -> Result (U32, BufferHeadOffset) ()
+
+-- buffer_head_serialise_Ple16
+--
+{-# cinline buffer_head_serialise_Ple16 #-}
+buffer_head_serialise_Ple16: (BufferHead, BufferHeadOffset, U16) -> Result (BufferHead, BufferHeadOffset) (BufferHead)
+
+-- buffer_head_deserialise_Ple16
+--
+{-# cinline buffer_head_deserialise_Ple16 #-}
+buffer_head_deserialise_Ple16: (BufferHead!, BufferHeadOffset) -> Result (U16, BufferHeadOffset) ()
+
+-- buffer_head_serialise_U8
+--
+{-# cinline buffer_head_serialise_U8 #-}
+buffer_head_serialise_U8: (BufferHead, BufferHeadOffset, U8) -> Result (BufferHead, BufferHeadOffset) (BufferHead)
+
+-- buffer_head_deserialise_U8
+--
+{-# cinline buffer_head_deserialise_U8 #-}
+buffer_head_deserialise_U8: (BufferHead!, BufferHeadOffset) -> Result (U8, BufferHeadOffset) ()
+
+
+--
+-- Helper functions
+--
+-- buffer_head_find:
+--  This function takes 4 arguments: (haystack, needle, offset, length) to find
+--  the buffer
+{-# cinline buffer_head_find #-}
+buffer_head_find: (BufferHead!, U8, BufferHead, U32) -> U32
+
+-- buffer_head_memset:
+--
+{-# cinline buffer_head_memset #-}
+buffer_head_memset: (BufferHead, BufferHeadOffset, U32, U32) -> BufferHead
+
+-- buffer_head_all_zeroes:
+-- check if a buffer was all zeroes between [from, to)
+buffer_head_all_zeroes: (BufferHead!, BufferHeadOffset, U32) -> Bool
+buffer_head_all_zeroes (buf, from, to) = buffer_head_find (buf, 0, from, to - from) >= to
+
+-- buffer_head_find_next_zero_bit:
+--
+{-# cinline buffer_head_find_next_zero_bit #-}
+buffer_head_find_next_zero_bit: (BufferHead!, U32, BufferHeadOffset) -> BufferHeadOffset
+
+-- buffer_head_set_bit:
+--
+{-# cinline buffer_head_set_bit #-}
+buffer_head_set_bit: (BufferHead, BufferHeadOffset) -> (BufferHead, Bool)
+
+-- buffer_head_clear_bit:
+--
+{-# cinline buffer_head_clear_bit #-}
+buffer_head_clear_bit: (BufferHead, BufferHeadOffset) -> (BufferHead, Bool)
+
+-- buffer_head_test_bit:
+--
+{-# cinline buffer_head_test_bit #-}
+buffer_head_test_bit: (BufferHead!, U32) -> Bool


### PR DESCRIPTION
We currently have `OSBuffer`(in osbuffer.cogent and osbuffer.ac) which is
a wrapper over `struct buffer_head`. This patch creates a new
implementation called `BufferHead`, which reflects the name of the actual
structure in the Linux kernel. And also cleans up the current
implementation.
I've created new files for this implementation (`bufferhead.cogent` and
`bufferhead.ac`) and retaining the old implementation until we transition
over to the new implementation everywhere.

This patch also adds:
* `SysState` to `common.cogent`, which is the eventual replacement for
  `ExState`. We are still retaining `ExState` until we make sure that
  transition has occured smoothly.
* Created a common `abstract-defns.h` file in `lib/c/linux` - this file
  is going to hold the definitions of all the abstract data types that
  the filesystem implementations are going to use.