### PR TITLE
[libgum] Wrappers for spin_lock and spin_unlock.

### DIFF
--- a/cogent/lib/gum/anti/os.ac
+++ b/cogent/lib/gum/anti/os.ac
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016, NICTA
+ * Copyright 2017, NICTA
  *
  * This software may be distributed and modified according to the terms of
  * the GNU General Public License version 2. Note that NO WARRANTY is provided.
@@ -8,7 +8,7 @@
  * @TAG(NICTA_GPL)
  */
 
-$ty:((ExState, OSTimeSpec)) os_get_current_time ($ty:(ExState) args)
+$ty:((ExState, OSTimeSpec)) os_get_current_time($ty:(ExState) args)
 {
     $ty:((ExState, OSTimeSpec)) ret;
 
@@ -21,17 +21,31 @@ $ty:((ExState, OSTimeSpec)) os_get_current_time ($ty:(ExState) args)
     return ret;
 }
 
-u32 os_get_current_fsgid ($ty:(ExState!) args)
+u32 os_get_current_fsgid($ty:(ExState!) args)
 {
-    return from_kgid (&init_user_ns, current_fsgid());
+    return from_kgid(&init_user_ns, current_fsgid());
 }
 
-u32 os_get_current_fsuid ($ty:(ExState!) args)
+u32 os_get_current_fsuid($ty:(ExState!) args)
 {
-    return from_kuid (&init_user_ns, current_fsuid());
+    return from_kuid(&init_user_ns, current_fsuid());
 }
 
-u32 os_get_pid ($ty:(()) args)
+u32 os_get_pid($ty:(ExState!) args)
 {
     return current->pid;
+}
+
+$ty:((ExState, #SpinLock)) os_spin_lock($ty:((ExState, #SpinLock)) args)
+{
+        spin_lock(&args.p2);
+
+        return args;
+}
+
+$ty:((ExState, #SpinLock)) os_spin_unlock($ty:((ExState, #SpinLock)) args)
+{
+        spin_unlock(&args.p2);
+
+        return args;
 }

--- a/cogent/lib/gum/kernel/linux/os.cogent
+++ b/cogent/lib/gum/kernel/linux/os.cogent
@@ -1,5 +1,5 @@
 --
--- Copyright 2016, NICTA
+-- Copyright 2017, NICTA
 --
 -- This software may be distributed and modified according to the terms of
 -- the GNU General Public License version 2. Note that NO WARRANTY is provided.
@@ -10,6 +10,15 @@
 
 include "../../common/common.cogent"
 
+
+-- spinlock_t
+type SpinLock
+
+-- This is the abstract type for struct dir_context
+type OSDirContext
+type OSPageOffset = U64
+
+
 os_PAGE_CACHE_SIZE : U64
 os_PAGE_CACHE_SIZE = 4096
 
@@ -18,8 +27,6 @@ os_PAGE_CACHE_MASK = complement (os_PAGE_CACHE_SIZE - 1)
 
 os_PAGE_CACHE_SHIFT: U64
 os_PAGE_CACHE_SHIFT = 12
-
-
 
 os_MAX_LFS_FILESIZE: U64
 
@@ -43,15 +50,18 @@ u64_to_TimeSpec v =
 
 {-# cinline os_get_current_time #-}
 os_get_current_time: ExState -> (ExState, OSTimeSpec)
+
 {-# cinline os_get_current_fsuid #-}
 os_get_current_fsuid: ExState! -> U32
+
 {-# cinline os_get_current_fsgid #-}
 os_get_current_fsgid: ExState! -> U32
 
--- FIXME: should take ExState
-os_get_pid: () -> U32
+{-# cinline os_get_pid #-}
+os_get_pid: ExState! -> U32
 
-type OSDirContext
+{-# cinline os_spin_lock #-}
+os_spin_lock: (ExState, #SpinLock) -> (ExState, #SpinLock)
 
-
-type OSPageOffset = U64
+{-# cinline os_spin_unlock #-}
+os_spin_unlock: (ExState, #SpinLock) -> (ExState, #SpinLock)


### PR DESCRIPTION
This patch adds Cogent wrappers for `spin_lock` and `spin_unlock`. We also
remove a `FIXME` in `os.cogent`.