### PR TITLE
[libgum] Remove duplicate `SysState` declaration.

### DIFF
--- a/cogent/lib/gum/common/common.cogent
+++ b/cogent/lib/gum/common/common.cogent
@@ -20,7 +20,6 @@ type RR c a b = (c, <Success a | Error b>)
 
 type ErrCode = U32
 type WordArrayIndex = U32
-type SysState
 
 -- SysState is the state that we will be carrying around and used in all functions
 -- that modify an external state in the system. This will abstract away, from Cogent,


### PR DESCRIPTION
The commit `ead63ccc60da6b8adebeeafb94d8d2cd8cb0f83b` breaks the build
because of the duplicate `type SysState` declaration.