### PR TITLE
[bilby] Fix bilby typecheck tests.

### DIFF
--- a/impl/fs/bilby/proof/ROOT
+++ b/impl/fs/bilby/proof/ROOT
@@ -9,7 +9,7 @@
  *)
 
 session CogentUtil = "HOL-Word" +
-  theories "../../../cogent/isa/Util"
+  theories "../../../../cogent/isa/Util"
 
 session "BilbyFsCode" (main) = "CogentUtil" +
   description {* BilbyFs implementation *}

--- a/impl/fs/bilby/proof/lib/L4vBucket.thy
+++ b/impl/fs/bilby/proof/lib/L4vBucket.thy
@@ -10,7 +10,7 @@
 
 theory L4vBucket
 imports
-  "../../../../l4v/lib/WordLemmaBucket"
+  "../../../../../l4v/lib/WordLemmaBucket"
 begin
 
 no_notation fun_app (infixr "$" 10)

--- a/impl/fs/bilby/test/regtest
+++ b/impl/fs/bilby/test/regtest
@@ -10,7 +10,7 @@
 #
 
 cd "$(dirname "${BASH_SOURCE[0]}")"
-source ../../../build-env.sh
+source ../../../../build-env.sh
 
 check_output() {
   local text ret


### PR DESCRIPTION
There's a regression because of commit dc6bd0fb4d1538a9bc11a68679abaf8e3f6b3362
and this patch fixes that.