### PR TITLE
[impl] Port fs modules to kernel version > 4.4

### DIFF
--- a/cogent/cogent.cabal
+++ b/cogent/cogent.cabal
@@ -86,9 +86,9 @@ Library
               , bytestring >= 0.10
               , containers >= 0.5
               , cpphs >=1.19
-              , directory >=1.2
+              , directory >=1.2 && <= 1.4
               , disassembler >= 0.2.0.0
-              , either >= 4.3.2
+              , either >= 4.3.2 && <= 4.4.1.1
               , extra >= 1.3
               , filepath >= 1.4.0.0
               , flippers >= 1.0.0
@@ -102,14 +102,14 @@ Library
               , mainland-pretty >= 0.2.6
               , MissingH >= 1.3
               , monoid-subclasses >= 0.4
-              , mtl >= 2.2.1
-              , parsec >= 3.0
+              , mtl >= 2.2.1 && < 2.3
+              , parsec >= 3.1
               , pretty-show >= 1.5
               , process >= 1.2.0.0
               , random >= 1.1
               , reducers >= 3.10
               , srcloc >= 0.4
-              , syb >= 0.3.7
+              , syb >= 0.4
               , template-haskell >= 2.9
               , text >= 0.11.3.1
               , time >= 1.5
@@ -152,7 +152,7 @@ executable cogent
               , atomic-write >= 0.2.0.4
               , base >= 4.7 && < 4.10
               , containers >= 0.5
-              , directory >=1.2 && <= 1.3
+              , directory >=1.2 && <= 1.4
               , either >= 4.3.2
               , filepath >= 1.4.0.0
               , mainland-pretty >= 0.2.6
@@ -189,7 +189,7 @@ test-suite test-util
                 cogent
               , base >= 4.7 && < 4.10
               , containers >= 0.5
-              , directory >=1.2
+              , directory >=1.2 && <= 1.4
               , filepath >= 1.4.0.0
-              , mtl >= 2.2.1
+              , mtl >= 2.2.1 && < 2.3
 

--- a/cogent/lib/gum/anti/ospage.ac
+++ b/cogent/lib/gum/anti/ospage.ac
@@ -84,8 +84,11 @@ $ty:(R OSPage ()) ospagecache_grab ($ty:((VfsMemoryMap, U64)) args) {
 unit_t ospagecache_release ($ty:(OSPage) page) {
     unit_t ret;
 
-    // printk ("releasing page %p from pagecache\n", page);
-    page_cache_release (page);
+$escstm:(#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0))
+    page_cache_release(page);
+$escstm:(#else)
+    put_page(page);
+$escstm:(#endif)
 
     return ret;
 }

--- a/cogent/main/Main.hs
+++ b/cogent/main/Main.hs
@@ -91,7 +91,8 @@ import System.IO
 import System.Process (readProcessWithExitCode)
 import Text.Show.Pretty (ppShow)
 import Text.PrettyPrint.ANSI.Leijen as LJ (displayIO, Doc, hPutDoc, plain)
-import Text.PrettyPrint.Mainland as M (ppr, hPutDoc, line, string, (</>))
+import Text.PrettyPrint.Mainland as M (hPutDoc, line, string, (</>))
+import Text.PrettyPrint.Mainland.Class as MC (ppr)
 import Prelude hiding (mapM_)
 
 -- import Debug.Trace
@@ -747,7 +748,7 @@ parseArgs args = case getOpt' Permute options args of
         Left err -> hPutStrLn stderr ("Glue code (types) generation failed: \n" ++ err) >> exitFailure
         Right infed -> do forM_ infed $ \(filename, defs) -> do
                             writeFileMsg $ Just filename
-                            output (Just filename) $ flip M.hPutDoc (M.ppr defs </> M.line)
+                            output (Just filename) $ flip M.hPutDoc (MC.ppr defs </> M.line)
       resAcFiles <- processAcFiles __cogent_infer_c_func_files glreader log
       if not __cogent_interactive
         then earlyExit resAcFiles
@@ -778,7 +779,7 @@ parseArgs args = case getOpt' Permute options args of
             Left err -> hPutStrLn stderr ("Glue code (functions) generation failed: \n" ++ err) >> return False
             Right infed -> do forM_ infed $ \(filename, defs) -> do
                                 writeFileMsg (Just filename)
-                                output (Just filename) $ flip M.hPutDoc (M.string ("/*\n" ++ log ++ "\n*/\n") </> M.ppr defs </> M.line)
+                                output (Just filename) $ flip M.hPutDoc (M.string ("/*\n" ++ log ++ "\n*/\n") </> MC.ppr defs </> M.line)
                               return True
         earlyExit :: Bool -> IO ()
         earlyExit x = if x then return () else exitFailure

--- a/cogent/src/Cogent/CodeGen.hs
+++ b/cogent/src/Cogent/CodeGen.hs
@@ -85,6 +85,7 @@ import           Prelude             as P    hiding (mapM)
 import           System.IO (Handle)
 import qualified Text.PrettyPrint.ANSI.Leijen as PP hiding ((<$>), (<>))
 import qualified Text.PrettyPrint.Mainland as ML
+import qualified Text.PrettyPrint.Mainland.Class as MLC
 
 -- import Debug.Trace
 import Unsafe.Coerce (unsafeCoerce)
@@ -1319,7 +1320,7 @@ cExtDecl (CMacro s) = C.EscDef s noLoc
 cExtDecl (CFnMacro fn as body) = C.EscDef (string1 ++ "\\\n" ++ string2) noLoc
   where macro1, macro2 :: ML.Doc
         macro1 = ML.string "#define" ML.<+> ML.string fn ML.<> ML.parens (ML.commasep $ L.map ML.string as)
-        macro2 = ML.ppr [citems| $items:(L.map cBlockItem body) |]
+        macro2 = MLC.ppr [citems| $items:(L.map cBlockItem body) |]
         string1, string2 :: String
         string1 = L.filter (/= '\n') $ ML.pretty 100 macro1
         string2 = concat $ map (\c -> if c == '\n' then "\\\n" else [c]) $ ML.pretty 100 macro2

--- a/impl/fs/ext2/cogent/plat/linux/inode.ac
+++ b/impl/fs/ext2/cogent/plat/linux/inode.ac
@@ -13,8 +13,14 @@ int ext2fs_mkdir(struct inode * dir, struct dentry * dentry, umode_t mode);
 int ext2fs_link(struct dentry * old_dentry, struct inode * dir, struct dentry *dentry);
 int ext2fs_unlink(struct inode * dir, struct dentry * dentry);
 int ext2fs_rmdir(struct inode * dir, struct dentry *dentry);
+$esc:(#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0))
 int ext2fs_rename(struct inode * old_dir, struct dentry * old_dentry,
-		  struct inode * new_dir, struct dentry * new_dentry);
+                  struct inode * new_dir, struct dentry * new_dentry);
+$esc:(#else)
+int ext2fs_rename(struct inode * old_dir, struct dentry * old_dentry,
+                  struct inode * new_dir, struct dentry * new_dentry,
+                  unsigned int flags);
+$esc:(#endif)
 int ext2fs_mknod(struct inode * dir, struct dentry *dentry, umode_t mode, dev_t rdev);
 int ext2fs_setattr(struct dentry *dentry, struct iattr *iattr);
 int ext2fs_iterate(struct file *file, struct dir_context *ctx);

--- a/impl/fs/ext2/cogent/plat/linux/wrapper.ac
+++ b/impl/fs/ext2/cogent/plat/linux/wrapper.ac
@@ -159,7 +159,11 @@ int ext2fs_setattr(struct dentry *dentry, struct iattr *iattr)
     Ext2State *state = inode->i_sb->s_fs_info;
     int error;
 
+$escstm:(#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0))
     error = inode_change_ok(inode, iattr);
+$escstm:(#else)
+    error = setattr_prepare(dentry, iattr);
+$escstm:(#endif)
     if (error) {
         return error;
     }
@@ -296,9 +300,6 @@ int ext2fs_mknod(struct inode * dir, struct dentry *dentry, umode_t mode, dev_t 
     int err = 0;
     $ty:(RR (SysState, FsState, VfsInode) VfsInode U32) mknod_res;
 
-    if (!new_valid_dev(rdev)) {
-        return -EINVAL;
-    }
 
     /* NOTE:We use WordArray_u8 instead of $ty:(WordArray U8) because we do not want the
       cogent compiler to use the pointer type. We want to allocate the wordarray on the
@@ -439,8 +440,9 @@ int ext2fs_unlink(struct inode * dir, struct dentry * dentry)
     return err;
 }
 
+$esc:(#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0))
 int ext2fs_rename(struct inode * old_dir, struct dentry * old_dentry,
-        struct inode * new_dir, struct dentry * new_dentry)
+                  struct inode * new_dir, struct dentry * new_dentry)
 {
     int err = 0;
     Ext2State *state = old_dir->i_sb->s_fs_info;
@@ -545,6 +547,118 @@ int ext2fs_rename(struct inode * old_dir, struct dentry * old_dentry,
 
     return err;
 }
+
+$esc:(#else)
+
+int ext2fs_rename(struct inode * old_dir, struct dentry * old_dentry,
+                  struct inode * new_dir, struct dentry * new_dentry,
+                  unsigned int flags)
+{
+    int err = 0;
+    Ext2State *state = old_dir->i_sb->s_fs_info;
+
+    // old_dir -> src_dir
+    // new_dir -> dest_dir OR if they're the same
+    //
+    // src_inode -> old_dentry->d_inode
+    // src_name -> old_dentry->d_name
+    //
+    // dest_inode -> new_dentry->d_inode if we're renaming over an existing link
+    // dest_name -> new_dentry->d_name
+
+    VfsInode* src_dir = EXT2_I(old_dir);
+    VfsInode* dest_dir = EXT2_I(new_dir);
+
+    VfsInode* src_inode = EXT2_I(old_dentry->d_inode);
+    struct inode *new_inode = new_dentry->d_inode;
+
+
+    /* NOTE:We use WordArray_u8 instead of $ty:(WordArray U8) because we do not want the
+      cogent compiler to use the pointer type. We want to allocate the wordarray on the
+      stack */
+    WordArray_u8 src_name_array = {.len = old_dentry->d_name.len, .values = (u8*)old_dentry->d_name.name };
+    WordArray_u8 dest_name_array = {.len = new_dentry->d_name.len, .values = (u8*)new_dentry->d_name.name };
+    $ty:(VfsRenameDirs) dirs;
+    $ty:(Option VfsInode) option_dest;
+    $ty:(RR (SysState, FsState, VfsRenameContext) () U32) rename_ret;
+
+    /* construct VfsRenameDirsDiff, if required */
+    if (src_dir != dest_dir) {
+        dirs.tag = TAG_ENUM_SrcDest;
+        dirs.SrcDest.src_dir = src_dir;
+        dirs.SrcDest.dest_dir = dest_dir;
+
+    } else {
+        dirs.tag = TAG_ENUM_Dest;
+        dirs.Dest = dest_dir;
+    }
+
+    /* construction option type for destination inode */
+    if (new_inode) {
+        VfsInode* dest_inode = EXT2_I (new_inode);
+        option_dest.Some = dest_inode;
+        option_dest.tag = TAG_ENUM_Some;
+    } else {
+        option_dest.tag = TAG_ENUM_None;
+    }
+
+    /* construct VfsRenameContext */
+    $ty:(VfsRenameContext) rename_ctx = {
+        // .dirs = dirs,
+
+        .src_inode = src_inode,
+        .src_name = &src_name_array,
+
+        // .dest_inode = option_dest,
+        .dest_name = &dest_name_array
+    };
+
+    rename_ctx.dirs = dirs;
+    rename_ctx.dest_inode = option_dest;
+
+    $ty:((SysState, FsState, VfsRenameContext)) rename_args = {
+        .p1 = state,
+        .p2 = state->priv,
+        .p3 = rename_ctx
+    };
+
+    /************ critical section begin ************/
+    ihold(old_dir);
+    ihold(new_dir);
+    ihold(old_dentry->d_inode);
+    if (new_dentry->d_inode) {
+        ihold(new_dentry->d_inode);
+    }
+
+    down(&state->iop_lock);
+
+    rename_ret = fsop_rename(rename_args);
+    WARN_ON(old_dir->i_state & I_NEW);
+    WARN_ON(new_dir->i_state & I_NEW);
+    WARN_ON(old_dentry->d_inode->i_state & I_NEW);
+
+    if (new_dentry->d_inode) {
+        WARN_ON(new_dentry->d_inode->i_state & I_NEW);
+    }
+
+    up(&state->iop_lock);
+
+    if (new_dentry->d_inode) {
+        iput(new_dentry->d_inode);
+    }
+    iput(old_dentry->d_inode);
+    iput(new_dir);
+    iput(old_dir);
+    /************  critical section end  ************/
+
+    if (rename_ret.p2.tag == TAG_ENUM_Error) {
+        err = -((int)rename_ret.p2.Error);
+    }
+
+    return err;
+}
+$esc:(#endif)                   /* LINUX_VERSION_CODE */
+
 
 int ext2fs_create(struct inode * dir, struct dentry * dentry, umode_t mode, bool excl)
 {

--- a/impl/fs/vfat/cogent/plat/linux/adt.h
+++ b/impl/fs/vfat/cogent/plat/linux/adt.h
@@ -22,6 +22,7 @@
 #include <linux/module.h>
 #include <linux/init.h>
 #include <linux/fs.h>
+#include <linux/version.h>
 #endif  /* __KERNEL__ */
 
 #endif /* _ADT_LINUX_H */

--- a/impl/fs/vfat/cogent/plat/linux/dir.c
+++ b/impl/fs/vfat/cogent/plat/linux/dir.c
@@ -777,7 +777,11 @@ static int fat_ioctl_readdir(struct inode *inode, struct file *file,
 
 	buf.dirent = dirent;
 	buf.result = 0;
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
 	mutex_lock(&inode->i_mutex);
+#else
+       inode_lock_shared(inode);
+#endif
 	buf.ctx.pos = file->f_pos;
 	ret = -ENOENT;
 	if (!IS_DEADDIR(inode)) {
@@ -785,7 +789,11 @@ static int fat_ioctl_readdir(struct inode *inode, struct file *file,
 				    short_only, both ? &buf : NULL);
 		file->f_pos = buf.ctx.pos;
 	}
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,4,0)
 	mutex_unlock(&inode->i_mutex);
+#else
+        inode_unlock_shared(inode);
+#endif
 	if (ret >= 0)
 		ret = buf.result;
 	return ret;

--- a/impl/fs/vfat/cogent/plat/linux/fat.h
+++ b/impl/fs/vfat/cogent/plat/linux/fat.h
@@ -15,6 +15,7 @@
 #include <linux/hash.h>
 #include <linux/ratelimit.h>
 #include <linux/msdos_fs.h>
+#include <linux/version.h>
 
 /*
  * vfat shortname flags
@@ -124,7 +125,7 @@ struct msdos_inode_info {
 	/* for avoiding the race between fat_free() and fat_get_cluster() */
 	unsigned int cache_valid_id;
 
-	/* NOTE: mmu_private is 64bits, so must hold ->i_mutex to access */
+	/* NOTE: mmu_private is 64bits, so must hold inode lock to access */
 	loff_t mmu_private;	/* physically allocated size */
 
 	int i_start;		/* first cluster or 0 */

--- a/impl/fs/vfat/cogent/plat/linux/nfs.c
+++ b/impl/fs/vfat/cogent/plat/linux/nfs.c
@@ -270,7 +270,7 @@ struct inode *fat_rebuild_parent(struct super_block *sb, int parent_logstart)
  * Find the parent for a directory that is not currently connected to
  * the filesystem root.
  *
- * On entry, the caller holds d_inode(child_dir)->i_mutex.
+ * On entry, the caller holds lock on d_inode(child_dir)
  */
 static struct dentry *fat_get_parent(struct dentry *child_dir)
 {

--- a/isa-parser/isa-parser.cabal
+++ b/isa-parser/isa-parser.cabal
@@ -34,9 +34,9 @@ library
 
   build-depends:       
     ansi-wl-pprint >= 0.6,
-    base >= 4.7, 
+    base >= 4.7 && < 4.10,
     haskell-src-meta >= 0.6,
-    mtl >= 2.1 && < 2.3, 
+    mtl >= 2.2.1 && < 2.3,
     parsec >= 3.1,
     syb >= 0.4,
     template-haskell >= 2.9


### PR DESCRIPTION
This patch ports the Cogent fs modules `vfat` and `ext2` to support the
recent kernels(4.4 and later).

Unfortunately, there is a fair bit of redundant code, because of an
issue with the anit-quotation(`Language.C.Parser` and
`Language.C.Quote`), they (and hence Cogent) expects a statement in a
function to end with a ';' and that results in a warning about a stray
';' generated by the CPP. And hence the duplication.

This patch doesn't include port the bilby implementation, since it isn't
as straightforward. I'm working on that patch, and will send it soon.

I've also remove code to run on kernel version < 3.16, we don't support
them anymore.

Fixes #65.