### PR TITLE
Export autogen modules so package can be used as a dependency

### DIFF
--- a/cogent/cogent.cabal
+++ b/cogent/cogent.cabal
@@ -92,9 +92,11 @@ library
               , Cogent.TypeProofs
               , Cogent.Util
               , Cogent.Vec
-
-  other-modules:
               -- Generated
+              , Paths_cogent
+              , Version_cogent
+
+  autogen-modules:
                 Paths_cogent
               , Version_cogent
 


### PR DESCRIPTION
these modules need to be exported for cogent to be included as a library dependency.