### PR TITLE
proof: fix the proofs in Cogent.thy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,13 @@ sudo apt-get install python-lxml python-psutil python-pycparser # regression tes
 
 To install the Cogent compiler, consult file [cogent/README.md](./cogent/README.md) for details. 
 
-[`l4v`](https://github.com/seL4/l4v/tree/47d5b746fc2f052586db11aa6048c5ae7c357155) and [`isabelle`](https://github.com/seL4/isabelle/tree/Isabelle2015) are two submodules in the repository.
+[`l4v`](https://github.com/seL4/l4v/tree/47d5b746fc2f052586db11aa6048c5ae7c357155) and [`isabelle`](https://github.com/seL4/isabelle/tree/Isabelle2017) are two submodules in the repository.
 To get them: `git submodule update --init --recursive`.
 
 If you already have them on your machine, you can symlink them as `l4v` and `isabelle` respectively
 in the top-level directory of this repository and checkout relevant revisions:
 * `l4v`: `ffc7b107e5bd5978295da61f64ea87b9ea3ad4d1`
-* `isabelle`: any Isabelle2015 revision
+* `isabelle`: any Isabelle2017 revision
 
 Add `isabelle/bin` to your PATH: `export PATH="$(pwd)/isabelle/bin:$PATH"`
 If you have an existing Isabelle install, you may want to set `ISABELLE_IDENTIFIER` instead of `PATH`.

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1098,7 +1098,7 @@ shows "\<Xi> , K , \<Gamma> \<turnstile>  e  : \<tau>  \<Longrightarrow> \<Xi> ,
 and   "\<Xi> , K , \<Gamma> \<turnstile>* es : \<tau>s \<Longrightarrow> \<Xi> , K' , instantiate_ctx \<delta> \<Gamma> \<turnstile>* map (specialise \<delta>) es : map (instantiate \<delta>) \<tau>s"
   using assms
 proof (induct rule: typing_typing_all.inducts)
-next case (typing_case K \<Gamma> \<Gamma>1 \<Gamma>2 \<Xi> x ts tag t a u b)
+  case (typing_case K \<Gamma> \<Gamma>1 \<Gamma>2 \<Xi> x ts tag t a u b)
   then have "\<Xi>, K', instantiate_ctx \<delta> \<Gamma> \<turnstile> Case (specialise \<delta> x) tag (specialise \<delta> a) (specialise \<delta> b) : instantiate \<delta> u"
     using image_iff
       filter_fst_ignore_triple[where ls=ts and f="\<lambda>(t,b). (instantiate \<delta> t, b)" and P="\<lambda>p. p \<noteq> tag"]
@@ -1141,6 +1141,8 @@ next
         by blast
     qed
   qed simp+
+  then show ?case
+    by simp
 next
   case (typing_esac \<Xi> K \<Gamma> x ts uu t)
   then show ?case


### PR DESCRIPTION
The main difference between here and 354f7bc is that I changed the typing_prom rule to have
    ∀c t b. (c,t,b) ∈ set ts ⟶ (∃b'. (b' ⟶ b) ∧ ((c,(t,b')) ∈ set ts'))
instead of
   (c,t,b) ∈ set ts ⟶ ((c,t,b') ∈ set ts' ∧ (b' ⟶ b))

I believe this is justified, since the old one is essentially the same as
   ∃c t b b'. (c,t,b) ∈ set ts ⟶ ((c,t,b') ∈ set ts' ∧ (b' ⟶ b))
which presumably is not what we want