### PR TITLE
Update update semantics

### DIFF
--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1187,32 +1187,12 @@ lemma bang_type_repr [simp]:
 shows "[] \<turnstile> t :\<kappa> k \<Longrightarrow> (type_repr (bang t) = type_repr t)"
 and   "[] \<turnstile>* ts :\<kappa> k \<Longrightarrow> (map (type_repr \<circ> bang) ts) = map (type_repr) ts "
 and   "[] \<turnstile>* fs :\<kappa>r k \<Longrightarrow> (map (type_repr \<circ>  bang \<circ> fst) fs) = map (type_repr  \<circ> fst) fs"
-proof (induct "[] :: kind list" t k
-      and "[] :: kind list" ts k
-      and "[] :: kind list" fs k
-      rule: kinding_kinding_all_kinding_record.inducts)
+by ( induct "[] :: kind list"  t k
+           and "[] :: kind list" ts k
+           and "[] :: kind list" fs k
+     rule: kinding_kinding_all_kinding_record.inducts
+   , auto, (case_tac s,auto)+)
 
-  case (kind_tsum ts k)
-
-  have f1: "(\<lambda>(c, \<tau>, y). \<not> y) \<circ> (\<lambda>(c, t, b). (c, bang t, b)) = (\<lambda>(c, \<tau>, y). \<not> y)"
-    by fastforce
-  have f2: "(\<lambda>(c, \<tau>, _). (c, type_repr \<tau>)) \<circ> (\<lambda>(c, t, b). (c, bang t, b)) = (\<lambda>(c, \<tau>, _). (c, type_repr (bang \<tau>)))"
-    by fastforce
-
-  have "map (\<lambda>(c, \<tau>, _). (c, type_repr \<tau>)) [(c, \<tau>, b)\<leftarrow>ts . \<not> b]
-         = map (\<lambda>(c, \<tau>, _). (c, type_repr (bang \<tau>))) [(c, \<tau>, b)\<leftarrow>ts . \<not> b]"
-    using kind_tsum.hyps by auto
-  then show ?case
-    by (simp add: filter_map f1 f2)
-next
-  case (kind_tcon ts k s n)
-  then show ?case
-    by (case_tac s, auto)
-next
-  case (kind_trec ts k s)
-  then show ?case
-    by (case_tac s, auto)
-qed simp+
 
 subsection {* Specialisation *} 
 

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -233,6 +233,18 @@ proof -
     by simp
 qed
 
+lemma tagged_list_update_same_distinct_is_equal[simp]:
+  assumes distinct_fst_xs: "distinct (map fst xs)"
+    and "i < length xs"
+    and "(xs ! i) = (tag, b)"
+  shows "tagged_list_update tag b xs = xs"
+  using assms
+proof (induct xs arbitrary: i)
+  case (Cons a xs)
+  then show ?case
+    by (metis fst_conv list_update_id tagged_list_update_distinct)
+qed simp+
+
 
 section {* Terms and Types of Cogent *}
 

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -740,7 +740,7 @@ datatype repr = RPtr repr
 fun type_repr :: "type \<Rightarrow> repr" where
   "type_repr (TFun t t')          = RFun"
 | "type_repr (TPrim t)            = RPrim t"
-| "type_repr (TSum ts)            = RSum (map (\<lambda>(a,(b,_)).(a, type_repr b)) ts)"
+| "type_repr (TSum ts)            = RSum (map (\<lambda>(a,(b,_)).(a, type_repr b)) [(c, \<tau>, y)\<leftarrow>ts . \<not> y])"
 | "type_repr (TProduct a b)       = RProduct (type_repr a) (type_repr b)"
 | "type_repr (TCon n ts Unboxed)  = RCon n (map type_repr ts)"
 | "type_repr (TCon n ts _)        = RPtr (RCon n (map type_repr ts))"

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -740,7 +740,7 @@ datatype repr = RPtr repr
 fun type_repr :: "type \<Rightarrow> repr" where
   "type_repr (TFun t t')          = RFun"
 | "type_repr (TPrim t)            = RPrim t"
-| "type_repr (TSum ts)            = RSum (map (\<lambda>(a,(b,_)).(a, type_repr b)) [(c, \<tau>, y)\<leftarrow>ts . \<not> y])"
+| "type_repr (TSum ts)            = RSum (map (\<lambda>(a,(b,_)).(a, type_repr b)) ts)"
 | "type_repr (TProduct a b)       = RProduct (type_repr a) (type_repr b)"
 | "type_repr (TCon n ts Unboxed)  = RCon n (map type_repr ts)"
 | "type_repr (TCon n ts _)        = RPtr (RCon n (map type_repr ts))"

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -217,7 +217,7 @@ lemma tagged_list_update_different_tag_preserves_values2:
   "\<lbrakk> (tag, b) \<in> set xs; tag \<noteq> tag' \<rbrakk> \<Longrightarrow> (tag, b) \<in> set (tagged_list_update tag' b' xs)"
   by (induct xs, (fastforce simp add: nth_Cons')+)
 
-lemma tagged_list_update_distinct[simp]:
+lemma tagged_list_update_distinct:
   assumes "distinct (map fst xs)"
     and "i < length xs"
   and "fst (xs ! i) = tag"
@@ -233,7 +233,7 @@ proof -
     by simp
 qed
 
-lemma tagged_list_update_same_distinct_is_equal[simp]:
+lemma tagged_list_update_same_distinct_is_equal:
   assumes distinct_fst_xs: "distinct (map fst xs)"
     and "i < length xs"
     and "(xs ! i) = (tag, b)"

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -200,6 +200,34 @@ lemma tagged_list_update_map_over:
   shows "map (\<lambda>(tag,b). (f tag, g tag b)) (tagged_list_update tag b' xs) = tagged_list_update (f tag) (g tag b') (map (\<lambda>(tag,b). (f tag, g tag b)) xs)"
   by (induct xs, (simp add: inj_eq case_prod_beta inj_f)+)
 
+lemma tagged_list_update_preserves_tags[simp]:
+  shows "map fst (tagged_list_update tag b' xs) = map fst xs"
+  by (induct xs, clarsimp+)
+
+lemma tagged_list_update_different_tag_preserves_values1[simp]:
+  "fst (xs ! i) \<noteq> tag \<Longrightarrow> (tagged_list_update tag b' xs) ! i = xs ! i"
+  by (induct xs arbitrary: i, (fastforce simp add: nth_Cons')+)
+
+lemma tagged_list_update_different_tag_preserves_values2:
+  "\<lbrakk> (tag, b) \<in> set xs; tag \<noteq> tag' \<rbrakk> \<Longrightarrow> (tag, b) \<in> set (tagged_list_update tag' b' xs)"
+  by (induct xs, (fastforce simp add: nth_Cons')+)
+
+lemma tagged_list_update_distinct[simp]:
+  assumes "distinct (map fst xs)"
+    and "i < length xs"
+  and "fst (xs ! i) = tag"
+shows "(tagged_list_update tag b' xs) = (xs[i := (tag, b')])"
+proof -
+  have "\<And>j. j < length xs \<Longrightarrow> i \<noteq> j \<Longrightarrow> fst (xs ! j) \<noteq> tag"
+    using assms
+    by (clarsimp simp add: distinct_conv_nth)
+  then have "\<forall>j<i. fst (xs ! j) \<noteq> tag"
+    using assms(2) by auto
+  then show ?thesis
+    using tagged_list_update_tag_present assms
+    by simp
+qed
+
 
 section {* Terms and Types of Cogent *}
 

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -194,11 +194,16 @@ proof (induct xs arbitrary: i)
   qed (simp add: case_prod_beta)
 qed simp
 
-lemma tagged_list_update_map_over:
+lemma tagged_list_update_map_over1:
   fixes f g
   assumes inj_f: "inj f"
   shows "map (\<lambda>(tag,b). (f tag, g tag b)) (tagged_list_update tag b' xs) = tagged_list_update (f tag) (g tag b') (map (\<lambda>(tag,b). (f tag, g tag b)) xs)"
   by (induct xs, (simp add: inj_eq case_prod_beta inj_f)+)
+
+lemma tagged_list_update_map_over2:
+  assumes "\<And>tag b'. f (tag, b') = (tag, g b')"
+  shows "map f (tagged_list_update tag b' xs) = tagged_list_update tag (g b') (map f xs)"
+  using assms by (induct xs, clarsimp+)
 
 lemma tagged_list_update_preserves_tags[simp]:
   shows "map fst (tagged_list_update tag b' xs) = map fst xs"
@@ -1283,7 +1288,7 @@ proof (induct rule: typing_typing_all.inducts)
     have "\<Xi>, K', instantiate_ctx \<delta> (Some (TSum (tagged_list_update tag (t, True) ts)) # \<Gamma>2) \<turnstile> specialise \<delta> b : instantiate \<delta> u"
       using typing_case.hyps(8) typing_case.prems by blast
     moreover have "(map (\<lambda>(c, t, b). (c, instantiate \<delta> t, b)) (tagged_list_update tag (t, True) ts)) = (tagged_list_update tag (instantiate \<delta> t, True) (map (\<lambda>(c, t, b). (c, instantiate \<delta> t, b)) ts))"
-      using case_prod_conv f1 tagged_list_update_map_over[where f = id and g = "\<lambda>_ (t,b). (instantiate \<delta> t, b)", simplified]
+      using case_prod_conv f1 tagged_list_update_map_over1[where f = id and g = "\<lambda>_ (t,b). (instantiate \<delta> t, b)", simplified]
       by metis
     ultimately show "\<Xi>, K', Some (TSum (tagged_list_update tag (instantiate \<delta> t, True) (map (\<lambda>(c, t, b). (c, instantiate \<delta> t, b)) ts))) # instantiate_ctx \<delta> \<Gamma>2 \<turnstile> specialise \<delta> b : instantiate \<delta> u"
       by clarsimp

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1187,12 +1187,32 @@ lemma bang_type_repr [simp]:
 shows "[] \<turnstile> t :\<kappa> k \<Longrightarrow> (type_repr (bang t) = type_repr t)"
 and   "[] \<turnstile>* ts :\<kappa> k \<Longrightarrow> (map (type_repr \<circ> bang) ts) = map (type_repr) ts "
 and   "[] \<turnstile>* fs :\<kappa>r k \<Longrightarrow> (map (type_repr \<circ>  bang \<circ> fst) fs) = map (type_repr  \<circ> fst) fs"
-by ( induct "[] :: kind list"  t k
-           and "[] :: kind list" ts k
-           and "[] :: kind list" fs k
-     rule: kinding_kinding_all_kinding_record.inducts
-   , auto, (case_tac s,auto)+)
+proof (induct "[] :: kind list" t k
+      and "[] :: kind list" ts k
+      and "[] :: kind list" fs k
+      rule: kinding_kinding_all_kinding_record.inducts)
 
+  case (kind_tsum ts k)
+
+  have f1: "(\<lambda>(c, \<tau>, y). \<not> y) \<circ> (\<lambda>(c, t, b). (c, bang t, b)) = (\<lambda>(c, \<tau>, y). \<not> y)"
+    by fastforce
+  have f2: "(\<lambda>(c, \<tau>, _). (c, type_repr \<tau>)) \<circ> (\<lambda>(c, t, b). (c, bang t, b)) = (\<lambda>(c, \<tau>, _). (c, type_repr (bang \<tau>)))"
+    by fastforce
+
+  have "map (\<lambda>(c, \<tau>, _). (c, type_repr \<tau>)) [(c, \<tau>, b)\<leftarrow>ts . \<not> b]
+         = map (\<lambda>(c, \<tau>, _). (c, type_repr (bang \<tau>))) [(c, \<tau>, b)\<leftarrow>ts . \<not> b]"
+    using kind_tsum.hyps by auto
+  then show ?case
+    by (simp add: filter_map f1 f2)
+next
+  case (kind_tcon ts k s n)
+  then show ?case
+    by (case_tac s, auto)
+next
+  case (kind_trec ts k s)
+  then show ?case
+    by (case_tac s, auto)
+qed simp+
 
 subsection {* Specialisation *} 
 

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -146,9 +146,6 @@ next
     by (clarsimp, blast)
 qed
 
-(* NOTE maybe we could just use maps in the type???
-        There are some disadvantages to this approach, namely loosing finiteness,
-        and thus the ability to search the values. *)
 lemma append_filter_fst_eqiv_map_update:
   assumes "set xs = map_pairs (map_of xs)"
     shows "(set ((fst z, f z) # [x\<leftarrow>xs. fst x \<noteq> fst z])) = (map_pairs ((map_of xs) (fst z \<mapsto> f z)))"
@@ -158,11 +155,6 @@ lemma append_filter_fst_eqiv_map_update:
   apply (subst Collect_disj_eq[symmetric])
   apply force
   done
-
-
-
-
-
 
 
 section {* Terms and Types of Cogent *}

--- a/cogent/isa/UpdateSemantics.thy
+++ b/cogent/isa/UpdateSemantics.thy
@@ -1206,7 +1206,7 @@ and  "\<Xi>, \<sigma> \<turnstile>* fs :ur ts \<langle>r, w\<rangle> \<Longright
 proof (induct rule: uval_typing_uval_typing_record.inducts)
   case (u_t_sum \<Xi> \<sigma> a t r w g ts rs)
   then show ?case
-    sorry
+    by clarsimp
 qed (force dest: abs_typing_repr intro: list_all2_helper2 [symmetric])+
 
 lemma type_repr_uval_repr_deep:
@@ -1215,7 +1215,7 @@ and  "\<Xi>, \<sigma> \<turnstile>* fs :ur ts \<langle>r, w\<rangle> \<Longright
 proof (induct rule: uval_typing_uval_typing_record.inducts)
   case (u_t_sum \<Xi> \<sigma> a t r w g ts rs)
   then show ?case
-    sorry
+    by clarsimp
 qed (force dest: abs_typing_repr intro: list_all2_helper2 [symmetric])+
 
 

--- a/cogent/isa/UpdateSemantics.thy
+++ b/cogent/isa/UpdateSemantics.thy
@@ -1249,20 +1249,14 @@ using assms(2,1) by ( induct "map snd tsa" "map snd rs"
 lemma type_repr_uval_repr:
 shows"\<Xi>, \<sigma> \<turnstile> v :u t \<langle>r, w\<rangle> \<Longrightarrow> uval_repr v = type_repr t"
 and  "\<Xi>, \<sigma> \<turnstile>* fs :ur ts \<langle>r, w\<rangle> \<Longrightarrow> map snd fs = map (\<lambda> a. (type_repr (fst a))) ts"
-proof (induct rule: uval_typing_uval_typing_record.inducts)
-  case (u_t_sum \<Xi> \<sigma> a t r w g ts rs)
-  then show ?case
-    sorry
-qed (force dest: abs_typing_repr intro: list_all2_helper2 [symmetric])+
+  by (induct rule: uval_typing_uval_typing_record.inducts,
+      (force dest: abs_typing_repr intro: list_all2_helper2 [symmetric])+)
 
 lemma type_repr_uval_repr_deep:
 shows"\<Xi>, \<sigma> \<turnstile> v :u t \<langle>r, w\<rangle> \<Longrightarrow> uval_repr_deep v = type_repr t"
 and  "\<Xi>, \<sigma> \<turnstile>* fs :ur ts \<langle>r, w\<rangle> \<Longrightarrow> map uval_repr_deep (map fst fs) = map (\<lambda> a. (type_repr (fst a))) ts"
-proof (induct rule: uval_typing_uval_typing_record.inducts)
-  case (u_t_sum \<Xi> \<sigma> a t r w g ts rs)
-  then show ?case
-    sorry
-qed (force dest: abs_typing_repr intro: list_all2_helper2 [symmetric])+
+  by (induct rule: uval_typing_uval_typing_record.inducts,
+      (force dest: abs_typing_repr intro: list_all2_helper2 [symmetric])+)
 
 
 lemma uval_typing_record_take:

--- a/cogent/isa/UpdateSemantics.thy
+++ b/cogent/isa/UpdateSemantics.thy
@@ -1226,7 +1226,7 @@ and  "\<Xi>, \<sigma> \<turnstile>* fs :ur ts \<langle>r, w\<rangle> \<Longright
 proof (induct rule: uval_typing_uval_typing_record.inducts)
   case (u_t_sum \<Xi> \<sigma> a t r w g ts rs)
   then show ?case
-    by clarsimp
+    sorry
 qed (force dest: abs_typing_repr intro: list_all2_helper2 [symmetric])+
 
 lemma type_repr_uval_repr_deep:
@@ -1235,7 +1235,7 @@ and  "\<Xi>, \<sigma> \<turnstile>* fs :ur ts \<langle>r, w\<rangle> \<Longright
 proof (induct rule: uval_typing_uval_typing_record.inducts)
   case (u_t_sum \<Xi> \<sigma> a t r w g ts rs)
   then show ?case
-    by clarsimp
+    sorry
 qed (force dest: abs_typing_repr intro: list_all2_helper2 [symmetric])+
 
 

--- a/cogent/isa/UpdateSemantics.thy
+++ b/cogent/isa/UpdateSemantics.thy
@@ -81,7 +81,7 @@ where
                    \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> (\<sigma>, App x y) \<Down>! st"
 
 | u_sem_con     : "\<lbrakk> \<xi> , \<gamma> \<turnstile> (\<sigma>, x) \<Down>! (\<sigma>', x') 
-                   \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> (\<sigma>, Con ts t x) \<Down>! (\<sigma>', USum t x' (map (\<lambda>(n,t). (n,type_repr t)) [x\<leftarrow>ts. fst x = t]))"
+                   \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> (\<sigma>, Con ts t x) \<Down>! (\<sigma>', USum t x' (map (\<lambda>(n,t). (n,type_repr t)) ts))"
 
 | u_sem_promote : "\<lbrakk> \<xi> , \<gamma> \<turnstile> (\<sigma>, x) \<Down>! (\<sigma>', USum c p rs)  
                    \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> (\<sigma>, Promote ts' x) \<Down>! (\<sigma>', USum c p (map (\<lambda>(n,t,_). (n, type_repr t)) (filter (HOL.Not \<circ> snd \<circ> snd) ts')))"
@@ -114,9 +114,9 @@ where
                    ; \<xi> , (v # \<gamma>) \<turnstile> (\<sigma>', m) \<Down>! st
                    \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> (\<sigma>, Case x t m n) \<Down>! st"
 
-| u_sem_case_nm : "\<lbrakk> \<xi> , \<gamma> \<turnstile> (\<sigma>, x) \<Down>! (\<sigma>', USum t' v ts)
+| u_sem_case_nm : "\<lbrakk> \<xi> , \<gamma> \<turnstile> (\<sigma>, x) \<Down>! (\<sigma>', USum t' v rs)
                    ; t' \<noteq> t
-                   ; \<xi> , (USum t' v (filter (\<lambda> x. fst x \<noteq> t) ts) # \<gamma>) \<turnstile> (\<sigma>', n) \<Down>! st
+                   ; \<xi> , (USum t' v rs # \<gamma>) \<turnstile> (\<sigma>', n) \<Down>! st
                    \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> (\<sigma>, Case x t m n) \<Down>! st"
 
 | u_sem_if      : "\<lbrakk> \<xi> , \<gamma> \<turnstile> (\<sigma>, x) \<Down>! (\<sigma>', UPrim (LBool b))
@@ -223,7 +223,7 @@ and uval_typing_record :: "('f \<Rightarrow> poly_type)
                   ; (tag, t, False) \<in> set ts
                   ; distinct (map fst ts)
                   ; [] \<turnstile>* map (fst \<circ> snd) ts wellformed
-                  ; rs = map (\<lambda>(c, \<tau>, _). (c, type_repr \<tau>)) [(c, \<tau>, b)\<leftarrow>ts. \<not> b]
+                  ; rs = map (\<lambda>(c, \<tau>, _). (c, type_repr \<tau>)) ts
                   \<rbrakk> \<Longrightarrow> \<Xi>, \<sigma> \<turnstile> USum tag a rs :u TSum ts \<langle>r, w\<rangle>"
 
 | u_t_struct   : "\<lbrakk> \<Xi>, \<sigma> \<turnstile>* fs :ur ts \<langle>r, w\<rangle> 

--- a/cogent/isa/UpdateSemantics.thy
+++ b/cogent/isa/UpdateSemantics.thy
@@ -352,7 +352,7 @@ definition proc_env_matches_ptrs :: "(('f,'a,'l) uabsfuns) \<Rightarrow> ('f \<R
 lemma uval_typing_to_kinding:
 shows "\<Xi>, \<sigma> \<turnstile> v :u t \<langle>r, w\<rangle> \<Longrightarrow> [] \<turnstile> t wellformed"
 and   "\<Xi>, \<sigma> \<turnstile>* fs :ur ts \<langle>r, w\<rangle> \<Longrightarrow> [] \<turnstile>* (map fst ts) wellformed"
-proof (induct  arbitrary: k rule: uval_typing_uval_typing_record.inducts)
+proof (induct rule: uval_typing_uval_typing_record.inducts)
 next case u_t_sum      then show ?case by (force intro: kinding_kinding_all_kinding_record.intros)
 next case u_t_struct   then show ?case by ( clarsimp
                                           , intro exI kinding_kinding_all_kinding_record.intros

--- a/cogent/isa/ValueSemantics.thy
+++ b/cogent/isa/ValueSemantics.thy
@@ -343,7 +343,8 @@ proof -
     moreover then have "\<And>tag \<tau>' b. (tag, \<tau>', b) \<in> set (ts[i := (tag', \<tau>, True)]) \<Longrightarrow> [] \<turnstile>  \<tau>' :\<kappa>  k"
       by (metis (no_types, lifting) fst_conv in_set_conv_nth length_list_update nth_list_update_eq nth_list_update_neq snd_conv)
     ultimately have "[] \<turnstile>* map (fst \<circ> snd) (tagged_list_update tag' (\<tau>, True) ts) :\<kappa> k"
-      using kinding_all_set ts_distinct by auto
+      using kinding_all_set ts_distinct
+      by (auto simp add: tagged_list_update_distinct)
     then show "[] \<turnstile>* map (fst \<circ> snd) (tagged_list_update tag' (\<tau>, True) ts) wellformed"
       using ts_distinct kinding_all_set
       by auto


### PR DESCRIPTION
Update the Update Semantics.

Most importantly:
I've changed the `repr` and `USum` to only hold the _untaken_ members of variants.

I needed to do this for minimal changes to the update semantics; but, I don't know what effects this might have on the non-updated portion of the proof-base.

