### PR TITLE
compiler: core/infer: insert Promote terms underneath Con

### DIFF
--- a/cogent/src/Cogent/Inference.hs
+++ b/cogent/src/Cogent/Inference.hs
@@ -386,9 +386,14 @@ infer (E (Tuple e1 e2))
    = do e1' <- infer e1
         e2' <- infer e2
         return $ TE (TProduct (exprType e1') (exprType e2')) (Tuple e1' e2')
-infer (E (Con tag e t))
+infer (E (Con tag e tfull))
    = do e' <- infer e
-        return $ TE t (Con tag e' t)
+        -- Find type of payload for given tag
+        let TSum ts          = tfull
+            Just (t, False) = lookup tag ts
+        -- Make sure to promote the payload to type t if necessary
+        e'' <- typecheck e' t
+        return $ TE tfull (Con tag e'' tfull)
 infer (E (If ec et ee))
    = do ec' <- infer ec
         guardShow "if-1" $ exprType ec' == TPrim Boolean

--- a/cogent/tests/pass_subtyping-con-promote.cogent
+++ b/cogent/tests/pass_subtyping-con-promote.cogent
@@ -1,0 +1,18 @@
+-- Test that the compiler is inserting promote terms inside variant constructors.
+-- These two functions should result in the same output core.
+-- Compile with something like:
+-- > cogent tests/pass_subtyping-con-promote.cogent --pretty-desugar
+
+-- The given value is a subtype of the variant's payload. The payload should be promoted.
+implicit_promote : () -> ()
+implicit_promote _
+  = let x = #{f1=1, f2=2}
+    and y : <A (#{f1 : U8, f2 : U8} take (f1,f2))> = A x
+    in ()
+
+-- The given value is a subtype of the variant's payload. We explicitly promote the payload.
+explicit_promote : () -> ()
+explicit_promote _
+  = let x = #{f1=1, f2=2}
+    and y : <A (#{f1 : U8, f2 : U8} take (f1,f2))> = A (x : (#{f1 : U8, f2 : U8} take (f1,f2)))
+    in ()


### PR DESCRIPTION
@zilinc @liamoc 

My understanding of the Core type system is that all subtyping requires
an explicit Promote term. I believe there is no implicit subsumption.

In the formalisation, the rule for variants is something like the following, and it requires
the expression type to be *strictly equal* to the type for the tag in the
variant type:

```
     ... |-  e : ts[tag]
---------------------------------
 ... |-   Con tag e ts : TSum ts
```

However, the compiler is currently generating core code that allows subtyping
underneath a Con, which would correspond to something like the following rule:

```
 ... |-  e : t'           t' <= ts[tag]
----------------------------------------
 ... |-   Con tag e ts : TSum ts
```

I think this is just a bug in the implementation of `infer`, as it was
not adding promote nodes everywhere that it should. I have
added the following test case, but unfortunately it compiles either way.
I'm not sure whether there's a way to require that a test case results
in particular core code.

Test case: these two functions should result in the same output core.

```
-- The given value is a subtype of the variant's payload. The payload should be promoted.
implicit_promote : () -> ()
implicit_promote _
  = let x = #{f1=1, f2=2}
    and y : <A (#{f1 : U8, f2 : U8} take (f1,f2))> = A x
    in ()

-- The given value is a subtype of the variant's payload. We explicitly promote the payload.
explicit_promote : () -> ()
explicit_promote _
  = let x = #{f1=1, f2=2}
    and y : <A (#{f1 : U8, f2 : U8} take (f1,f2))> = A (x : (#{f1 : U8, f2 : U8} take (f1,f2)))
    in ()
```