### PR TITLE
Proof of subtyping

### DIFF
--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1295,6 +1295,7 @@ next
     done
 qed (auto intro!: subtyping.intros)
 
+
 lemma subtyping_wellformed_preservation:
   assumes
     "K \<turnstile> t1 \<sqsubseteq> t2"

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -693,7 +693,7 @@ typing_var    : "\<lbrakk> K \<turnstile> \<Gamma> \<leadsto>w singleton (length
 
 | typing_con    : "\<lbrakk> \<Xi>, K, \<Gamma> \<turnstile> x : t
                    ; (tag, t', Unchecked) \<in> set ts
-                   ; K \<turnstile> t \<sqsubseteq> t'
+                   ; K \<turnstile> t' \<sqsubseteq> t
                    ; K \<turnstile> TSum ts' wellformed
                    ; distinct (map fst ts)
                    ; map fst ts = map fst ts'

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -694,7 +694,7 @@ typing_var    : "\<lbrakk> K \<turnstile> \<Gamma> \<leadsto>w singleton (length
 
 | typing_con    : "\<lbrakk> \<Xi>, K, \<Gamma> \<turnstile> x : t
                    ; (tag, t', Unchecked) \<in> set ts
-                   ; K \<turnstile> t' \<sqsubseteq> t
+                   ; K \<turnstile> t \<sqsubseteq> t'
                    ; K \<turnstile> TSum ts' wellformed
                    ; distinct (map fst ts)
                    ; map fst ts = map fst ts'

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -467,7 +467,8 @@ inductive subtyping :: "kind env \<Rightarrow> type \<Rightarrow> type \<Rightar
                   \<rbrakk> \<Longrightarrow> K \<turnstile> TFun t1 u1 \<sqsubseteq> TFun t2 u2"
 | subty_tprim  : "\<lbrakk> p1 = p2
                   \<rbrakk> \<Longrightarrow> K \<turnstile> TPrim p1 \<sqsubseteq> TPrim p2"
-| subty_trecord: "\<lbrakk> \<And>n t1 t2 b1 b2. \<lbrakk> (n,t1,b1) \<in> set ts1; (n,t2,b2) \<in> set ts2 \<rbrakk> \<Longrightarrow> (K \<turnstile> t1 \<sqsubseteq> t2) \<and> (b1 \<le> b2)
+| subty_trecord: "\<lbrakk> \<And>n t1 t2 b1 b2. \<lbrakk> (n,t1,b1) \<in> set ts1; (n,t2,b2) \<in> set ts2 \<rbrakk>
+                      \<Longrightarrow> (K \<turnstile> t1 \<sqsubseteq> t2) \<and> (b1 \<le> b2) (* (if K \<turnstile> t1 :\<kappa> {D} then b1 \<le> b2 else b1 = b2) *)
                   ; distinct (map fst ts1)
                   ; distinct (map fst ts2)
                   ; fst ` set ts1 = fst ` set ts2

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1285,7 +1285,6 @@ next
     done
 qed (auto intro!: subtyping.intros)
 
-
 lemma subtyping_wellformed_preservation:
   assumes
     "K \<turnstile> t1 \<sqsubseteq> t2"

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -692,16 +692,6 @@ typing_var    : "\<lbrakk> K \<turnstile> \<Gamma> \<leadsto>w singleton (length
                    ; \<Xi>, K, \<Gamma>2 \<turnstile> b : x
                    \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> App a b : y"
 
-| typing_con    : "\<lbrakk> \<Xi>, K, \<Gamma> \<turnstile> x : t
-                   ; (tag, t', Unchecked) \<in> set ts
-                   ; K \<turnstile> t \<sqsubseteq> t'
-                   ; K \<turnstile> TSum ts' wellformed
-                   ; distinct (map fst ts)
-                   ; map fst ts = map fst ts'
-                   ; map (fst \<circ> snd) ts = map (fst \<circ> snd) ts'
-                   ; list_all2 (\<lambda>x y. snd (snd x) \<le> snd (snd y)) ts ts'
-                   \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> Con ts tag x : TSum ts'"
-
 | typing_cast   : "\<lbrakk> \<Xi>, K, \<Gamma> \<turnstile> e : TPrim (Num \<tau>)
                    ; upcast_valid \<tau> \<tau>'
                    \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> Cast \<tau>' e : TPrim (Num \<tau>')"
@@ -727,6 +717,15 @@ typing_var    : "\<lbrakk> K \<turnstile> \<Gamma> \<leadsto>w singleton (length
                    ; K \<turnstile> t :\<kappa> k
                    ; E \<in> k
                    \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> LetBang is x y : u"
+
+| typing_con    : "\<lbrakk> \<Xi>, K, \<Gamma> \<turnstile> x : t
+                   ; (tag, t, Unchecked) \<in> set ts
+                   ; K \<turnstile> TSum ts' wellformed
+                   ; distinct (map fst ts)
+                   ; map fst ts = map fst ts'
+                   ; map (fst \<circ> snd) ts = map (fst \<circ> snd) ts'
+                   ; list_all2 (\<lambda>x y. snd (snd x) \<le> snd (snd y)) ts ts'
+                   \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> Con ts tag x : TSum ts'"
 
 | typing_case   : "\<lbrakk> K \<turnstile> \<Gamma> \<leadsto> \<Gamma>1 | \<Gamma>2
                    ; \<Xi>, K, \<Gamma>1 \<turnstile> x : TSum ts
@@ -1920,7 +1919,7 @@ next case (typing_fun \<Xi> K t f u t' ts u' ks \<Gamma>)
         typing_typing_all.typing_fun [simplified]
         instantiate_ctx_consumed)
 next
-  case (typing_con \<Xi> K \<Gamma> x t tag t' ts ts')
+  case (typing_con \<Xi> K \<Gamma> x t tag ts ts')
   then show ?case
   proof (clarsimp, intro typing_typing_all.intros)
        show "map (fst \<circ> snd) (map (\<lambda>(c, t, b). (c, instantiate \<delta> t, b)) ts) = map (fst \<circ> snd) (map (\<lambda>(c, t, b). (c, instantiate \<delta> t, b)) ts')"
@@ -1930,9 +1929,6 @@ next
   next show "K' \<turnstile> TSum (map (\<lambda>(c, t, b). (c, instantiate \<delta> t, b)) ts') wellformed"
       using typing_con
       by (fastforce intro: substitutivity instantiate_wellformed dest: list_all2_kinding_wellformedD list_all2_lengthD)
-  next show "K' \<turnstile> instantiate \<delta> t \<sqsubseteq> instantiate \<delta> t'"
-      using typing_con specialisation_subtyping subtyping_wellformed_preservation typing_to_wellformed
-      by blast
   qed (force intro: specialisation_subtyping substitutivity)+
 next case typing_esac then show ?case
     by (force intro!: typing_typing_all.typing_esac

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1374,6 +1374,32 @@ next
   qed auto
 qed simp+
 
+
+lemma subtyping_bang_preservation:
+  assumes "K \<turnstile> t1 \<sqsubseteq> t2"
+  shows "K \<turnstile> bang t1 \<sqsubseteq> bang t2"
+  using assms
+proof (induct rule: subtyping.induct)
+  case subty_tcon then show ?case
+    by (force simp add: list_all2_conv_all_nth intro: subtyping.intros)
+next
+  case (subty_trecord ts1 ts2 K s1 s2)
+  then show ?case
+  proof (simp, intro subtyping.intros)
+    assume "fst ` set ts1 = fst ` set ts2"
+    then show "fst ` set (map (\<lambda>(n, t, b). (n, bang t, b)) ts1) = fst ` set (map (\<lambda>(n, t, b). (n, bang t, b)) ts2)"
+      by (auto simp add: image_image case_prod_unfold)
+  qed auto
+next
+  case (subty_tsum ts1 ts2 K)
+  then show ?case
+  proof (simp, intro subtyping.intros)
+    assume "fst ` set ts1 = fst ` set ts2"
+    then show "fst ` set (map (\<lambda>(n, t, b). (n, bang t, b)) ts1) = fst ` set (map (\<lambda>(n, t, b). (n, bang t, b)) ts2)"
+      by (auto simp add: image_image case_prod_unfold)
+  qed auto
+qed (simp add: subtyping_simps)+
+
 section {* Typing lemmas *}
 
 lemma typing_all_Cons1I:

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1285,6 +1285,7 @@ next
     done
 qed (auto intro!: subtyping.intros)
 
+
 lemma subtyping_wellformed_preservation:
   assumes
     "K \<turnstile> t1 \<sqsubseteq> t2"

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -713,7 +713,7 @@ typing_var    : "\<lbrakk> K \<turnstile> \<Gamma> \<leadsto>w singleton (length
                    ; \<Xi>, K, (Some t # \<Gamma>2) \<turnstile> y : u
                    \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> Let x y : u"
 
-| typing_letb   : "\<lbrakk> split_bang K is \<Gamma> \<Gamma>1 \<Gamma>2
+| typing_letb   : "\<lbrakk> K, is \<turnstile> \<Gamma> \<leadsto>b \<Gamma>1 | \<Gamma>2
                    ; \<Xi>, K, \<Gamma>1 \<turnstile> x : t
                    ; \<Xi>, K, (Some t # \<Gamma>2) \<turnstile> y : u
                    ; K \<turnstile> t :\<kappa> k

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1277,44 +1277,6 @@ next
     by (intro subtyping.intros, auto simp add: list_all2_conv_all_nth list_all_iff)
 qed (auto intro!: subtyping.intros simp add: list.rel_refl_strong list_all_iff)
 
-lemma specialisation_subtyping:
-  assumes
-    "K \<turnstile> t \<sqsubseteq> t'"
-    "K \<turnstile> t wellformed"
-    "K \<turnstile> t' wellformed"
-    "list_all2 (kinding K') \<delta> K"
-  shows "K' \<turnstile> instantiate \<delta> t \<sqsubseteq> instantiate \<delta>  t'"
-  using assms
-proof (induct rule: subtyping.inducts)
-  case (subty_tvar i' i K)
-  then show ?case
-    by (auto intro!: subtyping.intros subtyping_refl simp add: kinding_def list_all2_conv_all_nth)
-next
-  case (subty_tvarb i' i K)
-  moreover then have "type_wellformed (length K') (bang (\<delta> ! i))"
-    by (auto dest: bang_wellformed simp add: kinding_def list_all2_conv_all_nth)
-  ultimately show ?case
-    by (auto intro!: subtyping.intros subtyping_refl simp add: kinding_def list_all2_conv_all_nth)
-next
-  case subty_tcon then show ?case
-    by (auto intro!: subtyping.intros subtyping_refl simp add: list_all_iff kinding_def list_all2_conv_all_nth)
-next
-  case (subty_trecord K ts1 ts2 s1 s2)
-  moreover then have "\<And>i. i < length ts1 \<Longrightarrow>
-    K' \<turnstile> instantiate \<delta> (fst (snd (ts1 ! i))) \<sqsubseteq> instantiate \<delta> (fst (snd (ts2 ! i)))"
-    by (auto simp add: list_all2_conv_all_nth list_all_length)
-  ultimately show ?case
-    by (fastforce intro!: subtyping.intros simp add: list_all2_conv_all_nth split: prod.splits)
-next
-  case (subty_tsum K ts1 ts2)
-  moreover then have "\<And>i. i < length ts1 \<Longrightarrow>
-    K' \<turnstile> instantiate \<delta> (fst (snd (ts1 ! i))) \<sqsubseteq> instantiate \<delta> (fst (snd (ts2 ! i)))"
-    by (auto simp add: list_all2_conv_all_nth list_all_length)
-  ultimately show ?case
-    by (fastforce intro!: subtyping.intros simp add: list_all2_conv_all_nth split: prod.splits)
-qed (auto intro!: subtyping.intros)
-
-
 lemma subtyping_wellformed_preservation:
   assumes
     "K \<turnstile> t1 \<sqsubseteq> t2"

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -319,6 +319,7 @@ datatype 'f expr = Var index
                  | Member "'f expr" field
                  | Unit
                  | Lit lit
+                 | SLit string
                  | Cast num_type "'f expr"
                  | Tuple "'f expr" "'f expr"
                  | Put "'f expr" field "'f expr"
@@ -442,6 +443,7 @@ fun specialise :: "type substitution \<Rightarrow> 'f expr \<Rightarrow> 'f expr
 | "specialise \<delta> (Unit)            = Unit"
 | "specialise \<delta> (Cast t e)        = Cast t (specialise \<delta> e)"
 | "specialise \<delta> (Lit v)           = Lit v"
+| "specialise \<delta> (SLit s)          = SLit s"
 | "specialise \<delta> (Tuple a b)       = Tuple (specialise \<delta> a) (specialise \<delta> b)"
 | "specialise \<delta> (Put e f e')      = Put (specialise \<delta> e) f (specialise \<delta> e')"
 | "specialise \<delta> (Let e e')        = Let (specialise \<delta> e) (specialise \<delta> e')"
@@ -751,6 +753,9 @@ typing_var    : "\<lbrakk> K \<turnstile> \<Gamma> \<leadsto>w singleton (length
 | typing_lit    : "\<lbrakk> K \<turnstile> \<Gamma> consumed
                    \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> Lit l : TPrim (lit_type l)"
 
+| typing_slit   : "\<lbrakk> K \<turnstile> \<Gamma> consumed
+                   \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> SLit s : TPrim String"
+
 | typing_unit   : "\<lbrakk> K \<turnstile> \<Gamma> consumed
                    \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> Unit : TUnit"
 
@@ -838,6 +843,7 @@ inductive atom ::"'f expr \<Rightarrow> bool" where
 | "atom (Member (Var x) f)"
 | "atom Unit"
 | "atom (Lit l)"
+| "atom (SLit l)"
 | "atom (Tuple (Var x) (Var y))"
 | "atom (Esac (Var x))"
 | "atom (App (Var a) (Var b))"
@@ -1967,6 +1973,7 @@ fun expr_size :: "'f expr \<Rightarrow> nat" where
 | "expr_size (AFun v va) = 0"
 | "expr_size (Struct v va) = Suc (sum_list (map expr_size va))"
 | "expr_size (Lit v) = 0"
+| "expr_size (SLit s) = 0"
 | "expr_size (Tuple v va) = Suc ((expr_size v) + (expr_size va))"
 | "expr_size (Put v va vb) = Suc ((expr_size v) + (expr_size vb))"
 | "expr_size (Esac x) = Suc (expr_size x)"

--- a/cogent/isa/Cogent.thy
+++ b/cogent/isa/Cogent.thy
@@ -1529,19 +1529,17 @@ lemma subtyping_preserves_type_repr:
 proof (induct rule: subtyping.induct)
   case (subty_trecord K ts1 ts2 s1 s2)
   then show ?case
-  (* I don't understand Isabelle:
-     > apply (cases s1, induct rule: list_all2_induct)
-     works, but separate apply calls don't work:
-     > apply (cases s1)
-     > apply (induct rule: list_all2_induct) -- fails
-     what's up with that
-  *)
     by (cases s1; induct rule: list_all2_induct; auto)
 next
   case (subty_tsum K ts1 ts2)
   then show ?case
     by (induct rule: list_all2_induct; auto)
 qed auto
+
+lemma subtyping_preserves_type_repr_map:
+  "list_all2 (\<lambda>p1 p2. [] \<turnstile> fst (snd p1) \<sqsubseteq> fst (snd p2)) as bs
+  \<Longrightarrow> map (type_repr \<circ> fst \<circ> snd) as = map (type_repr \<circ> fst \<circ> snd) bs"
+  by (induct rule: list_all2_induct, auto simp add: subtyping_preserves_type_repr)
 
 
 section {* Typing lemmas *}

--- a/cogent/isa/Subtyping.thy
+++ b/cogent/isa/Subtyping.thy
@@ -385,8 +385,8 @@ lemma type_lub_type_glb_order_correct: "a \<leftarrow> a \<squnion> b \<longleft
 
 lemma glb_lub_subtyping_order_correct:
   shows
-    "c \<leftarrow> a \<squnion> b \<Longrightarrow> (c \<sqsubseteq> a) \<and> (c \<sqsubseteq> b)"
-    "c \<leftarrow> a \<sqinter> b \<Longrightarrow> (a \<sqsubseteq> c) \<and> (b \<sqsubseteq> c)"
+    "c \<leftarrow> a \<squnion> b \<Longrightarrow> (K \<turnstile> c \<sqsubseteq> a) \<and> (K \<turnstile> c \<sqsubseteq> b)"
+    "c \<leftarrow> a \<sqinter> b \<Longrightarrow> (K \<turnstile> a \<sqsubseteq> c) \<and> (K \<turnstile> b \<sqsubseteq> c)"
 proof (induct rule: type_lub_type_glb.inducts)
   case (lub_tcon n n1 n2 s s1 s2 ts ts1 ts2)
   then show ?case
@@ -400,7 +400,7 @@ next
     moreover then obtain t2 b2 where "(n, t2, b2) \<in> set ts2"
       using lub_trecord.hyps
       by (metis (no_types, hide_lams) eq_fst_iff image_iff)
-    ultimately have "t \<sqsubseteq> t1 \<and> b \<le> b1"
+    ultimately have "K \<turnstile> t \<sqsubseteq> t1 \<and> b \<le> b1"
       using lub_trecord.hyps by fastforce
   }
   moreover { fix n t b t2 b2
@@ -410,7 +410,7 @@ next
     moreover then obtain t1 b1 where "(n, t1, b1) \<in> set ts1"
       using lub_trecord.hyps
       by (metis (no_types, hide_lams) eq_fst_iff image_iff)
-    ultimately have "t \<sqsubseteq> t2 \<and> b \<le> b2"
+    ultimately have "K \<turnstile> t \<sqsubseteq> t2 \<and> b \<le> b2"
       using lub_trecord.hyps by fastforce
   }
   moreover have
@@ -429,7 +429,7 @@ next
     moreover then obtain t2 b2 where "(n, t2, b2) \<in> set ts2"
       using lub_tsum.hyps
       by (metis (no_types, hide_lams) eq_fst_iff image_iff)
-    ultimately have "t \<sqsubseteq> t1 \<and> b \<le> b1"
+    ultimately have "K \<turnstile> t \<sqsubseteq> t1 \<and> b \<le> b1"
       using lub_tsum.hyps by fastforce
   }
   moreover { fix n t b t2 b2
@@ -439,7 +439,7 @@ next
     moreover then obtain t1 b1 where "(n, t1, b1) \<in> set ts1"
       using lub_tsum.hyps
       by (metis (no_types, hide_lams) eq_fst_iff image_iff)
-    ultimately have "t \<sqsubseteq> t2 \<and> b \<le> b2"
+    ultimately have "K \<turnstile> t \<sqsubseteq> t2 \<and> b \<le> b2"
       using lub_tsum.hyps by fastforce
   }
   moreover have
@@ -462,7 +462,7 @@ next
     moreover then obtain t2 b2 where "(n, t2, b2) \<in> set ts2"
       using glb_trecord.hyps
       by (metis (no_types, hide_lams) eq_fst_iff image_iff)
-    ultimately have "t1 \<sqsubseteq> t \<and> b1 \<le> b"
+    ultimately have "K \<turnstile> t1 \<sqsubseteq> t \<and> b1 \<le> b"
       using glb_trecord.hyps by fastforce
   }
   moreover { fix n t b t2 b2
@@ -472,7 +472,7 @@ next
     moreover then obtain t1 b1 where "(n, t1, b1) \<in> set ts1"
       using glb_trecord.hyps
       by (metis (no_types, hide_lams) eq_fst_iff image_iff)
-    ultimately have "t2 \<sqsubseteq> t \<and> b2 \<le> b"
+    ultimately have "K \<turnstile> t2 \<sqsubseteq> t \<and> b2 \<le> b"
       using glb_trecord.hyps by fastforce
   }
   moreover have
@@ -491,7 +491,7 @@ next
     moreover then obtain t2 b2 where "(n, t2, b2) \<in> set ts2"
       using glb_tsum.hyps
       by (metis (no_types, hide_lams) eq_fst_iff image_iff)
-    ultimately have "t1 \<sqsubseteq> t \<and> b1 \<le> b"
+    ultimately have "K \<turnstile> t1 \<sqsubseteq> t \<and> b1 \<le> b"
       using glb_tsum.hyps by fastforce
   }
   moreover { fix n t b t2 b2
@@ -501,7 +501,7 @@ next
     moreover then obtain t1 b1 where "(n, t1, b1) \<in> set ts1"
       using glb_tsum.hyps
       by (metis (no_types, hide_lams) eq_fst_iff image_iff)
-    ultimately have "t2 \<sqsubseteq> t \<and> b2 \<le> b"
+    ultimately have "K \<turnstile> t2 \<sqsubseteq> t \<and> b2 \<le> b"
       using glb_tsum.hyps by fastforce
   }
   moreover have
@@ -516,8 +516,8 @@ qed (auto intro!: subtyping.intros)
 
 lemma type_lub_type_glb_to_subtyping:
   shows
-    "a \<leftarrow> a \<squnion> b \<Longrightarrow> a \<sqsubseteq> b"
-    "b \<leftarrow> a \<sqinter> b \<Longrightarrow> a \<sqsubseteq> b"
+    "a \<leftarrow> a \<squnion> b \<Longrightarrow> K \<turnstile> a \<sqsubseteq> b"
+    "b \<leftarrow> a \<sqinter> b \<Longrightarrow> K \<turnstile> a \<sqsubseteq> b"
   using glb_lub_subtyping_order_correct
   by fast+
 

--- a/cogent/isa/UpdateSemantics.thy
+++ b/cogent/isa/UpdateSemantics.thy
@@ -703,6 +703,7 @@ next case (split_cons x xs a as b bs)
     done
     next case share with 3 show ?thesis
       apply (clarsimp dest!: split_cons(3))
+      apply (rule_tac V="S \<in> {S}" in revcut_rl, blast)
       apply (drule(2) shareable_not_writable)
       apply (clarsimp)
       apply (rule_tac x = "rx \<union> r'"  in exI)
@@ -852,7 +853,7 @@ next
       next
         case (share k)
         moreover then have w1_empty: "w1 = {}"
-          using shareable_not_writable split\<gamma> by fast
+          using shareable_not_writable split\<gamma> by blast
         moreover have "\<Xi>, \<sigma> \<turnstile> g # \<gamma>' matches Some t # as \<langle>r1 \<union> (r21 \<union> p), {} \<union> w21\<rangle>"
           using split\<gamma> split\<gamma>'
           by (intro matches_ptrs_some, auto simp add: w1_empty)

--- a/cogent/isa/Util.thy
+++ b/cogent/isa/Util.thy
@@ -159,6 +159,20 @@ lemma map_update_eq_if_indistinguishable:
   using assms
   by (metis list_update_id map_update)
 
+lemma map_proj_eq_set_zip_impl_proj_eq:
+  "map P as = map Q bs \<Longrightarrow>
+  (a,b) \<in> set (zip as bs) \<Longrightarrow>
+  P a = Q b"
+proof -
+  assume A:
+    "map P as = map Q bs"
+    "(a,b) \<in> set (zip as bs)"
+  have L: "length as = length bs"
+    using A map_eq_imp_length_eq by auto
+  from L A show "P a = Q b"
+    by (induct as bs rule: list_induct2; auto)
+qed
+
 lemma list_all2_update_second:
   assumes "list_all2 f xs (ys[i := a])"
     and "f (xs ! i) a \<Longrightarrow> f (xs ! i) b"
@@ -217,6 +231,24 @@ lemma list_all2_split_all:
    apply (induct rule: list_all2_induct, simp+)
   apply (induct xs arbitrary: ys; case_tac ys; clarsimp)
   done
+
+lemma list_all2_in_set1_impl_in_set_zip12_sat:
+  assumes
+    "list_all2 P xs ys"
+    "x \<in> set xs"
+  obtains y where
+    "(x,y) \<in> set (zip xs ys)"
+    "P x y"
+  using assms by (metis fst_conv in_set_impl_in_set_zip1 in_set_zip list_all2_conv_all_nth snd_conv)
+
+lemma list_all2_in_set_impl_sat:
+  assumes
+    "list_all2 P xs ys"
+    "(x,y) \<in> set (zip xs ys)"
+  shows
+    "P x y"
+  using assms
+  by (metis fst_conv in_set_zip list_all2_nthD snd_conv)
 
 
 subsection {* list_all3 *}

--- a/cogent/isa/Util.thy
+++ b/cogent/isa/Util.thy
@@ -116,6 +116,9 @@ lemma prod_eq:
 
 section {* list related lemmas *}
 
+lemma map_eq_iff_nth_eq: "(map f xs = map g ys) = (length xs = length ys \<and> (\<forall>i < length xs. f (xs ! i) = g (ys ! i)))"
+  by (force simp add: list_eq_iff_nth_eq)
+
 lemma map2_mapL: "List.map2 h (map f xs) xs = map (\<lambda>x. h (f x) x) xs"
   by (induction xs) (auto)
 
@@ -193,10 +196,27 @@ lemma distinct_fst_tags_update:
 lemma list_all_nil: "list_all P []" by simp
 lemma list_all_cons: "P x \<Longrightarrow> list_all P xs \<Longrightarrow> list_all P (x # xs)" by simp
 
+subsection {* list_all2 *}
 
+lemmas list_all2_nil = List.list.rel_intros(1)
+lemmas list_all2_cons = List.list.rel_intros(2)
 
 lemma list_all2_eq_iff_map_eq: "list_all2 (\<lambda>x y. f x = g y) xs ys = (map f xs = map g ys)"
   by (induct xs arbitrary: ys; simp add: Cons_eq_map_conv list_all2_Cons1)
+
+lemma list_all2_split_conj:
+  shows "list_all2 (\<lambda>x y. P x y \<and> Q x y) xs ys \<longleftrightarrow> list_all2 P xs ys \<and> list_all2 Q xs ys"
+  apply (rule iffI)
+   apply (induct rule: list_all2_induct, simp+)
+  apply (clarsimp, induct rule: list_all2_induct, simp+)
+  done
+
+lemma list_all2_split_all:
+  shows "list_all2 (\<lambda>x y. \<forall>a. P x y a) xs ys \<longleftrightarrow> (\<forall>a. list_all2 (\<lambda>x y. P x y a) xs ys)"
+  apply (rule iffI)
+   apply (induct rule: list_all2_induct, simp+)
+  apply (induct xs arbitrary: ys; case_tac ys; clarsimp)
+  done
 
 
 subsection {* list_all3 *}

--- a/cogent/isa/Util.thy
+++ b/cogent/isa/Util.thy
@@ -189,6 +189,16 @@ lemma distinct_fst_tags_update:
    apply (simp split: nat.split add: image_set map_update[symmetric] del: image_set[symmetric])+
   done
 
+
+lemma list_all_nil: "list_all P []" by simp
+lemma list_all_cons: "P x \<Longrightarrow> list_all P xs \<Longrightarrow> list_all P (x # xs)" by simp
+
+
+
+lemma list_all2_eq_iff_map_eq: "list_all2 (\<lambda>x y. f x = g y) xs ys = (map f xs = map g ys)"
+  by (induct xs arbitrary: ys; simp add: Cons_eq_map_conv list_all2_Cons1)
+
+
 subsection {* list_all3 *}
 
 inductive list_all3 :: "('a \<Rightarrow> 'b \<Rightarrow> 'c \<Rightarrow> bool) \<Rightarrow> 'a list \<Rightarrow> 'b list \<Rightarrow> 'c list \<Rightarrow> bool" where

--- a/cogent/isa/ValueSemantics.thy
+++ b/cogent/isa/ValueSemantics.thy
@@ -23,15 +23,24 @@ datatype ('f, 'a) vval = VPrim lit
                        | VFunction "'f expr" "type list"
                        | VAFunction "'f" "type list"
                        | VUnit
-                       | VPromote type "('f, 'a) vval"
 
 (* All polymorphic instantiations must have the _same_ value semantics. This means even if the C
 implementations differ they must all refine the same specification *)
 type_synonym ('f, 'a) vabsfuns = "'f \<Rightarrow> ('f, 'a) vval \<Rightarrow> ('f,'a) vval \<Rightarrow> bool"
 
+
 definition eval_prim :: "prim_op \<Rightarrow> ('f, 'a) vval list \<Rightarrow> ('f, 'a) vval"
 where
   "eval_prim pop xs = VPrim (eval_prim_op pop (map (\<lambda>vv. case vv of VPrim v \<Rightarrow> v | _ \<Rightarrow> LBool False) xs))"
+
+lemma eval_prim_type_change:
+assumes "(eval_prim :: prim_op \<Rightarrow> ('f1, 'a1) vval list \<Rightarrow> ('f1, 'a1) vval) p (map VPrim lits) = VPrim l"
+shows "(eval_prim :: prim_op \<Rightarrow> ('f2, 'a2) vval list \<Rightarrow> ('f2, 'a2) vval) p (map VPrim  lits) = VPrim l"
+proof -
+have helper: "(\<lambda>vv. case vv of VPrim v \<Rightarrow> v | _ \<Rightarrow> LBool False) \<circ> VPrim = id" by (rule ext, simp)
+then show ?thesis using assms by (simp add: eval_prim_def helper)
+qed
+section {* Semantics *}
 
 (* NOTE: Termination is currently not provable with this approach. It's possible to show
    it for v_sem assuming all called functions are terminating, but proving
@@ -123,14 +132,14 @@ where
                    \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> Split x e \<Down> e'"
 
 | v_sem_promote : "\<lbrakk> \<xi> , \<gamma> \<turnstile> e \<Down> e'
-                   \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> Promote t e \<Down> e'"
+                   \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> Promote t' e \<Down> e'"
 
 
 | v_sem_all_empty : "\<xi> , \<gamma> \<turnstile>* [] \<Down> []"
 
 | v_sem_all_cons  : "\<lbrakk> \<xi> , \<gamma> \<turnstile> x \<Down> v
                      ; \<xi> , \<gamma> \<turnstile>* xs \<Down> vs
-                     \<rbrakk> \<Longrightarrow>  \<xi> , \<gamma> \<turnstile>* (x # xs) \<Down> (v # vs)"
+                     \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile>* (x # xs) \<Down> (v # vs)"
 
 inductive_cases v_sem_varE  [elim] : "\<xi> , \<gamma> \<turnstile> Var i \<Down> v"
 inductive_cases v_sem_funE  [elim] : "\<xi> , \<gamma> \<turnstile> Fun f ts \<Down> v"
@@ -146,8 +155,6 @@ context value_sem begin
 
 inductive vval_typing  :: "('f \<Rightarrow> poly_type) \<Rightarrow> ('f, 'a) vval \<Rightarrow> type \<Rightarrow> bool"
           ("_ \<turnstile> _ :v _" [30,0,20] 80)
-and vval_typing_variant :: "('f \<Rightarrow> poly_type) \<Rightarrow> ('f, 'a) vval list \<Rightarrow> (name \<times> type \<times> variant_state) list \<Rightarrow> bool"
-          ("_ \<turnstile>* _ :vv _" [30,0,20] 80)
 and vval_typing_record :: "('f \<Rightarrow> poly_type) \<Rightarrow> ('f, 'a) vval list \<Rightarrow> (name \<times> type \<times> record_state) list \<Rightarrow> bool"
           ("_ \<turnstile>* _ :vr _" [30,0,20] 80) where
 
@@ -171,29 +178,29 @@ and vval_typing_record :: "('f \<Rightarrow> poly_type) \<Rightarrow> ('f, 'a) v
                   ; [] \<turnstile>* ts wellformed
                   \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile> VAbstract a :v TCon n ts s"
 
+(*
+  The term language type system uses an explicit subtyping rule (Promote), but we want a subtyping-implies-subset relation for values
+  so that we can upcast values without having to change their representation. This means we want implicit subsumption for values.
+  However, if we introduce a separate subsumption rule for values such as
+  | v_t_subsumption: " \<lbrakk> \<Xi> \<turnstile> v :v t ; [] \<turnstile> t \<sqsubseteq> t' \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile> v :v t' "
+  the canonical forms of values are less obvious.
+  Because our definition of subtyping is quite simple, we only really need subsumption for function values.
+  So for these two rules, we condense the v_t_subsumption and v_t_afun/v_t_function rules into one.
+  These rules still associate values with a concrete type constructor (TFun), which makes reasoning about canonical forms trivial.
+*)
 | v_t_afun     : "\<lbrakk> \<Xi> f = (ks, a, b)
                   ; list_all2 (kinding []) ts ks
                   ; ks \<turnstile> TFun a b wellformed
-                  \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile> VAFunction f ts :v TFun (instantiate ts a) (instantiate ts b)"
+                  ; [] \<turnstile> TFun (instantiate ts a) (instantiate ts b) \<sqsubseteq> TFun t' u'
+                  \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile> VAFunction f ts :v TFun t' u'"
 
 | v_t_function : "\<lbrakk> \<Xi> , K , [ Some t ] \<turnstile> f : u
                   ; K \<turnstile> t wellformed
                   ; list_all2 (kinding []) ts K
-                  \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile> VFunction f ts :v TFun (instantiate ts t) (instantiate ts u)"
+                  ; [] \<turnstile> TFun (instantiate ts t) (instantiate ts u) \<sqsubseteq> TFun t' u'
+                  \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile> VFunction f ts :v TFun t' u'"
 
 | v_t_unit     : "\<Xi> \<turnstile> VUnit :v TUnit"
-
-| v_t_promote  : "\<lbrakk> \<Xi> \<turnstile> e :v t'
-                  ; [] \<turnstile> t \<sqsubseteq> t'
-                  \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile> VPromote _ e :v t"
-
-| v_t_v_empty  : "\<Xi> \<turnstile>* [] :vr []"
-| v_t_v_cons1  : "\<lbrakk> \<Xi> \<turnstile> x :v t
-                  ; \<Xi> \<turnstile>* xs :vv ts
-                  \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile>* (x # xs) :vv ((n, t, Unchecked) # ts)"
-| v_t_v_cons2  : "\<lbrakk> [] \<turnstile> t wellformed
-                  ; \<Xi> \<turnstile>* xs :vv ts
-                  \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile>* (x # xs) :vv ((n, t, Checked) # ts)"
 
 | v_t_r_empty  : "\<Xi> \<turnstile>* [] :vr []"
 | v_t_r_cons1  : "\<lbrakk> \<Xi> \<turnstile> x :v t
@@ -215,9 +222,6 @@ inductive_cases v_t_recordE   [elim]: "\<Xi> \<turnstile> VRecord fs :v \<tau>"
 inductive_cases v_t_productE  [elim]: "\<Xi> \<turnstile> VProduct a b :v \<tau>"
 inductive_cases v_t_sumE'     [elim]: "\<Xi> \<turnstile> e :v TSum ts"
 inductive_cases v_t_primE     [elim]: "\<Xi> \<turnstile> VPrim l :v TPrim (Num \<tau>)"
-
-inductive_cases v_t_v_emptyE  [elim]: "\<Xi> \<turnstile>* [] :vv \<tau>s"
-inductive_cases v_t_v_consE   [elim]: "\<Xi> \<turnstile>* (x # xs) :vv \<tau>s"
 
 inductive_cases v_t_r_emptyE  [elim]: "\<Xi> \<turnstile>* [] :vr \<tau>s"
 inductive_cases v_t_r_consE   [elim]: "\<Xi> \<turnstile>* (x # xs) :vr \<tau>s"
@@ -246,39 +250,32 @@ section {* vval_typing lemmas *}
 
 lemma vval_typing_to_wellformed:
   shows "\<Xi> \<turnstile> v :v \<tau>     \<Longrightarrow> [] \<turnstile> \<tau> wellformed"
-    and "\<Xi> \<turnstile>* vs :vv cs \<Longrightarrow> [] \<turnstile>* map (fst \<circ> snd) cs wellformed"
     and "\<Xi> \<turnstile>* vs :vr fs \<Longrightarrow> [] \<turnstile>* map (fst \<circ> snd) fs wellformed"
-proof (induct rule: vval_typing_vval_typing_variant_vval_typing_record.inducts)
+proof (induct rule: vval_typing_vval_typing_record.inducts)
   case v_t_function then show ?case
-    by (auto intro!: instantiate_wellformed dest!: typing_to_wellformed
-        dest: list_all2_kinding_wellformedD list_all2_lengthD)
+    by (metis instantiate_wellformed list_all2_kinding_wellformedD subtyping_wellformed_preservation(1) type_wellformed.simps(4) type_wellformed_pretty_def typing_to_wellformed(1))
 next case v_t_afun  then show ?case
-    by (auto intro!: instantiate_wellformed dest!: typing_to_wellformed
-        dest: list_all2_kinding_wellformedD list_all2_lengthD)
-next case v_t_promote then show ?case
-    using subtyping_wellformed_preservation
-    by blast
-qed (auto intro: supersumption simp add: kinding_simps dest: kinding_all_record'[simplified o_def])
+    by (metis instantiate_wellformed list_all2_kinding_wellformedD subtyping_wellformed_preservation(1) type_wellformed.simps(4) type_wellformed_pretty_def)
+qed (auto intro: supersumption simp add: list_all_iff kinding_simps dest: kinding_all_record'[simplified o_def])
 
 lemma vval_typing_bang:
   shows "\<Xi> \<turnstile> x :v \<tau> \<Longrightarrow> \<Xi> \<turnstile> x :v bang \<tau>"
-    and "\<Xi> \<turnstile>* cs :vv \<tau>vs \<Longrightarrow> \<Xi> \<turnstile>* cs :vv map (\<lambda>(n, x, y). (n, bang x, y)) \<tau>vs"
     and "\<Xi> \<turnstile>* fs :vr \<tau>rs \<Longrightarrow> \<Xi> \<turnstile>* fs :vr map (\<lambda>(n, x, y). (n, bang x, y)) \<tau>rs"
-proof (induct rule: vval_typing_vval_typing_variant_vval_typing_record.inducts)
-     case v_t_sum      then show ?case by (force intro: vval_typing_vval_typing_variant_vval_typing_record.intros
+proof (induct rule: vval_typing_vval_typing_record.inducts)
+  case v_t_sum      then show ?case
+    by (force simp add: list_all_iff intro: vval_typing_vval_typing_record.intros
                                                         bang_wellformed rev_image_eqI)
-next case v_t_abstract then show ?case by (force intro: vval_typing_vval_typing_variant_vval_typing_record.intros
+next case v_t_abstract then show ?case by (force intro: vval_typing_vval_typing_record.intros
                                                         abs_typing_bang bang_wellformed)
-next case v_t_r_cons2  then show ?case by (force intro: vval_typing_vval_typing_variant_vval_typing_record.intros
+next case v_t_r_cons2  then show ?case by (force intro: vval_typing_vval_typing_record.intros
                                                         bang_wellformed)
-next case v_t_v_cons2  then show ?case by (force intro: vval_typing_vval_typing_variant_vval_typing_record.intros
-                                                        bang_wellformed)
-next
-  case (v_t_promote \<Xi> e t' K t)
-  then show ?case
-    by (force dest: subtyping_bang_preservation
-        intro: vval_typing_vval_typing_variant_vval_typing_record.intros)
-qed (force intro: vval_typing_vval_typing_variant_vval_typing_record.intros)+
+next case v_t_afun
+  show ?case
+    using subtyping_bang_preservation v_t_afun vval_typing_vval_typing_record.v_t_afun by fastforce
+next case v_t_function
+  show ?case
+    using subtyping_bang_preservation v_t_function.hyps vval_typing_vval_typing_record.v_t_function by fastforce
+qed (force intro: vval_typing_vval_typing_record.intros)+
 
 subsection {* vval_typing_record *}
 
@@ -305,7 +302,7 @@ lemma vval_typing_all_record:
 shows "\<Xi> \<turnstile>* vs :vr zip ns (zip ts (replicate (length ts) Present))"
   using assms[simplified vval_typing_all_def]
   by (induct arbitrary: ns rule: list_all2_induct)
-    (auto simp add: length_Suc_conv intro!: vval_typing_vval_typing_variant_vval_typing_record.intros)
+    (auto simp add: length_Suc_conv intro!: vval_typing_vval_typing_record.intros)
 
 lemma vval_typing_record_take:
   assumes "\<Xi> \<turnstile>* ts :vr \<tau>s"
@@ -320,8 +317,8 @@ proof (induct ts arbitrary: \<tau>s n f)
     using Cons.prems by blast
   ultimately show ?case
     by (cases taken, auto dest: kinding_to_wellformedD split: nat.splits
-        intro!: vval_typing_vval_typing_variant_vval_typing_record.intros)
-qed (force intro: vval_typing_vval_typing_variant_vval_typing_record.intros)
+        intro!: vval_typing_vval_typing_record.intros)
+qed (force intro: vval_typing_vval_typing_record.intros)
 
 lemma vval_typing_record_put:
 assumes "\<Xi> \<turnstile>* ts :vr \<tau>s"
@@ -331,11 +328,12 @@ and     "D \<in> k \<or> taken = Taken"
 and     "\<Xi> \<turnstile> v :v t"
 shows   "\<Xi> \<turnstile>* ts[ f := v ] :vr \<tau>s[ f := (n, t, Present) ]"
 using assms proof (induct ts arbitrary: \<tau>s f)
-     case Nil  then show ?case by ( force intro: vval_typing_vval_typing_variant_vval_typing_record.intros)
+     case Nil  then show ?case by ( force intro: vval_typing_vval_typing_record.intros)
 next case Cons then show ?case by ( cases taken
                                   , (force split: nat.split
-                                           intro!: vval_typing_vval_typing_variant_vval_typing_record.intros)+ )
+                                           intro!: vval_typing_vval_typing_record.intros)+ )
 qed
+
 
 subsection {* Sums and subtyping *}
 
@@ -372,9 +370,182 @@ proof -
   next
     show "[] \<turnstile> TSum (tagged_list_update tag' (\<tau>, Checked) ts) wellformed"
       using vval_elim_lemmas tag'_in_ts prod_in_set(1)
-      by (fastforce intro!: variant_tagged_list_update_wellformedI)
+      by (fastforce intro!: variant_tagged_list_update_wellformedI simp add: list_all_iff)
   qed simp+
 qed
+
+
+lemma value_subtyping_to_wellformed:
+  "K \<turnstile> t \<sqsubseteq> t'
+  \<Longrightarrow> \<Xi> \<turnstile> v :v t
+  \<Longrightarrow> K \<turnstile> t' wellformed"
+  by (metis instantiate_nothing kinding_iff_wellformed(1) list_all2_Nil substitutivity_single subtyping_wellformed_preservation(1) vval_typing_to_wellformed(1))
+
+lemma subtyping_record_cons_split:
+  "K \<turnstile> TRecord ((n,t1,b1) # ts1) s \<sqsubseteq> TRecord ts2 s \<Longrightarrow> \<exists>t2 b2 ts2'. ts2 = (n,t2,b2) # ts2' \<and>  (K \<turnstile> t1 \<sqsubseteq> t2) \<and> (if K \<turnstile> t1 :\<kappa> {D} then b1 \<le> b2 else b1 = b2)"
+proof -
+  assume subty_rec: "K \<turnstile> TRecord ((n,t1,b1) # ts1) s \<sqsubseteq> TRecord ts2 s"
+  obtain xts1 where xts1_def: "xts1 = ((n,t1,b1) # ts1)" by auto
+  have elims:
+    "list_all2 (\<lambda>p1 p2.
+        fst p1 = fst p2 \<and>
+        K \<turnstile> fst (snd p1) \<sqsubseteq> fst (snd p2) \<and> (if K \<turnstile> fst (snd p1) :\<kappa> {D} then snd (snd p1) \<le> snd (snd p2) else snd (snd p1) = snd (snd p2)))
+        xts1 ts2"
+    "distinct (map fst xts1)"
+    "distinct (map fst ts2)"
+    using subty_rec subtyping.cases xts1_def
+    by fast+
+
+  obtain t2 b2 ts2' where ts2_def: "ts2 = (n,t2,b2) # ts2'"
+    using elims xts1_def
+    by (cases ts2, auto)
+
+  then show ?thesis
+    using elims xts1_def by force
+qed
+
+lemma subtyping_record_uncons: "K \<turnstile> TRecord (t1 # ts1) s \<sqsubseteq> TRecord (t2 # ts2) s \<Longrightarrow> K \<turnstile> TRecord ts1 s \<sqsubseteq> TRecord ts2 s"
+proof -
+  assume subty_rec: "K \<turnstile> TRecord (t1 # ts1) s \<sqsubseteq> TRecord (t2 # ts2) s"
+  obtain xts1 where xts1_def: "xts1 = (t1 # ts1)" by auto
+  obtain xts2 where xts2_def: "xts2 = (t2 # ts2)" by auto
+  have elims:
+    "list_all2 (\<lambda>p1 p2.
+        fst p1 = fst p2 \<and>
+        K \<turnstile> fst (snd p1) \<sqsubseteq> fst (snd p2) \<and> (if K \<turnstile> fst (snd p1) :\<kappa> {D} then snd (snd p1) \<le> snd (snd p2) else snd (snd p1) = snd (snd p2)))
+        xts1 xts2"
+    "distinct (map fst xts1)"
+    "distinct (map fst xts2)"
+    using subty_rec subtyping.cases xts1_def xts2_def by fast+
+  show "K \<turnstile> TRecord ts1 s \<sqsubseteq> TRecord ts2 s"
+    using xts1_def xts2_def subty_trecord elims by force
+qed
+
+lemma value_subtyping:
+  shows "\<Xi> \<turnstile> v :v t \<Longrightarrow>[] \<turnstile> t \<sqsubseteq> t' \<Longrightarrow> \<Xi> \<turnstile> v :v t'"
+    and "\<Xi> \<turnstile>* vs :vr ts \<Longrightarrow> [] \<turnstile> TRecord ts s \<sqsubseteq> TRecord ts' s \<Longrightarrow>  \<Xi> \<turnstile>* vs :vr ts'"
+proof (induct arbitrary: t' and ts' rule: vval_typing_vval_typing_record.inducts)
+  case (v_t_product \<Xi> va ta vb tb)
+  obtain ta' tb' where elims:
+    "t' = TProduct ta' tb'"
+    "[] \<turnstile> ta \<sqsubseteq> ta'"
+    "[] \<turnstile> tb \<sqsubseteq> tb'"
+    using v_t_product by (auto elim: subtyping.cases intro: vval_typing_vval_typing_record.intros)
+  show ?case
+    using v_t_product elims by (simp add: vval_typing_vval_typing_record.intros)
+next
+  case (v_t_sum \<Xi> a ta n ts1)
+  let ?P = "(\<lambda>p1 p2. fst p1 = fst p2 \<and> [] \<turnstile> fst (snd p1) \<sqsubseteq> fst (snd p2) \<and> snd (snd p1) \<le> snd (snd p2))"
+  obtain ts2 where elims:
+    "t' = TSum ts2"
+    "list_all2 ?P ts1 ts2"
+    "distinct (map fst ts1)"
+    "distinct (map fst ts2)"
+    using v_t_sum
+    by (auto elim: subtyping.cases intro: vval_typing_vval_typing_record.intros)
+
+  obtain i where n_in_ts_ix:
+    "(n, ta, Unchecked) = ts1 ! i"
+    "i < length ts1"
+    using v_t_sum
+    by (metis in_set_conv_nth)
+
+  obtain n' ta' ba' where n'_in_ts2: "(n', ta', ba') = ts2 ! i"
+    by (metis prod_cases3)
+
+  have sat_ts1_ts2: "?P (ts1 ! i) (ts2 ! i)"
+    using elims n_in_ts_ix n'_in_ts2 list_all2_nthD
+    by blast
+
+  have sat_unroll:
+    "n = n'"
+    "[] \<turnstile> ta \<sqsubseteq> ta'"
+    "ba' = Unchecked"
+    using n_in_ts_ix n'_in_ts2 sat_ts1_ts2
+    by (metis fst_conv snd_conv less_eq_variant_state.elims(2))+
+
+  show ?case
+    using v_t_sum elims sat_unroll n'_in_ts2 n_in_ts_ix subtyping_wellformed_preservation value_sem.v_t_sum value_sem_axioms
+    by (metis (no_types, lifting) in_set_conv_nth list_all2_lengthD)
+next
+  case (v_t_record \<Xi> fs ts s)
+  obtain ts' where elims:
+    "t' = TRecord ts' s"
+    "distinct (map fst ts')"
+    using v_t_record by (auto elim: subtyping.cases intro: vval_typing_vval_typing_record.intros)
+
+  have "\<Xi> \<turnstile>* fs :vr ts'"
+    using elims subty_trecord subtyping_simps(6) v_t_record by presburger
+
+  then show ?case
+    using v_t_record elims  vval_typing_vval_typing_record.intros
+    by blast
+next
+  case (v_t_abstract a n ts \<Xi> s)
+  have "t' = TCon n ts s"
+    using subtyping.cases v_t_abstract by fastforce
+  then show ?case
+    using v_t_abstract vval_typing_vval_typing_record.v_t_abstract by blast
+next
+  case (v_t_afun \<Xi> f ks ta tb ts tfun')
+  then obtain tx ux where "t' = TFun tx ux"
+    by (auto elim: subtyping.cases)
+  then show ?case
+    using v_t_afun by (meson subtyping_trans vval_typing_vval_typing_record.intros)
+next
+  case (v_t_function \<Xi> K t f u ts t')
+  then obtain tx ux where "t' = TFun tx ux"
+    by (auto elim: subtyping.cases)
+  then show ?case
+    using v_t_function by (meson subtyping_trans vval_typing_vval_typing_record.intros)
+next
+  case (v_t_r_empty \<Xi>)
+  have "ts' = []"
+    using v_t_r_empty by (auto elim: subtyping.cases)
+  then show ?case
+    by (auto elim: subtyping.cases intro: vval_typing_vval_typing_record.intros)
+next
+  case (v_t_r_cons1 \<Xi> x t1 xs ts n)
+
+  obtain t2 b2 ts2' where field_is: "ts' = (n,t2,b2) # ts2'"
+    "([] \<turnstile> t1 \<sqsubseteq> t2)"
+    "(if [] \<turnstile> t1 :\<kappa> {D} then Present \<le> b2 else Present = b2)"
+    using subtyping_record_cons_split v_t_r_cons1 by blast
+
+  have field_rest: "\<Xi> \<turnstile>* xs :vr ts2'"
+    using v_t_r_cons1 field_is subtyping_record_uncons
+    by meson
+
+  then show ?case
+  proof (cases b2)
+    case Taken
+    then show ?thesis
+      using field_rest field_is v_t_r_cons1 vval_typing_vval_typing_record.v_t_r_cons2 value_subtyping_to_wellformed by metis
+  next case Present
+    then show ?thesis
+    using field_rest field_is v_t_r_cons1 vval_typing_vval_typing_record.v_t_r_cons1 by metis
+  qed
+next
+  case (v_t_r_cons2 t1 \<Xi> xs ts x n)
+
+  obtain t2 b2 ts2' where field_is: "ts' = (n,t2,b2) # ts2'"
+    "([] \<turnstile> t1 \<sqsubseteq> t2)"
+    "(if [] \<turnstile> t1 :\<kappa> {D} then Taken \<le> b2 else Taken = b2)"
+    using subtyping_record_cons_split v_t_r_cons2 by blast
+
+  have field_rest: "\<Xi> \<turnstile>* xs :vr ts2'"
+    using v_t_r_cons2 field_is subtyping_record_uncons
+    by meson
+
+  have b2_is: "b2 = Taken"
+    using field_is less_eq_record_state.elims
+    by metis
+
+  then show ?case
+    using field_rest field_is b2_is v_t_r_cons2 vval_typing_vval_typing_record.v_t_r_cons2
+    by (metis subtyping_wellformed_preservation(1))
+qed (auto elim: subtyping.cases intro: vval_typing_vval_typing_record.intros)
+
 
 subsection {* Introductions under instantiations *}
 
@@ -390,14 +561,22 @@ shows   "\<Xi> \<turnstile> VAFunction f (map (instantiate \<delta>) ts) :v TFun
                                                            (instantiate \<delta> (instantiate ts u))"
 proof -
   from assms
-  have "TFun (instantiate \<delta> (instantiate ts t))
+  have tfun_eq:
+      "TFun (instantiate \<delta> (instantiate ts t))
              (instantiate \<delta> (instantiate ts u))
       = TFun (instantiate (map (instantiate \<delta>) ts) t)
              (instantiate (map (instantiate \<delta>) ts) u)"
     by (force intro: instantiate_instantiate dest: list_all2_lengthD)
-  with assms show ?thesis
-    by (force simp add: kinding_simps
-        intro: vval_typing_vval_typing_variant_vval_typing_record.intros list_all2_substitutivity)
+
+  have tfun_sub:
+    "[] \<turnstile> TFun (instantiate (map (instantiate \<delta>) ts) t) (instantiate (map (instantiate \<delta>) ts) u)
+        \<sqsubseteq> TFun (instantiate       \<delta> (instantiate ts t)) (instantiate       \<delta> (instantiate ts u))"
+    using assms tfun_eq
+    by (metis (mono_tags, lifting) list_all2_substitutivity specialisation_subtyping subty_tfun subtyping_refl)
+
+  show ?thesis
+    using assms tfun_sub
+    by (meson list_all2_substitutivity type_wellformed.simps(4) type_wellformed_pretty_def v_t_afun)
 qed
 
 lemma v_t_function_instantiate:
@@ -412,10 +591,18 @@ from assms have "TFun (instantiate \<delta> (instantiate ts t))
                       (instantiate \<delta> (instantiate ts u))
                = TFun (instantiate (map (instantiate \<delta>) ts) t)
                       (instantiate (map (instantiate \<delta>) ts) u)"
-           by (force intro: instantiate_instantiate dest: list_all2_lengthD dest!: typing_to_wellformed)
-with assms show ?thesis by (force intro: vval_typing_vval_typing_variant_vval_typing_record.intros
-                                         list_all2_substitutivity
-                                  simp add: kinding_simps)
+  by (force intro: instantiate_instantiate dest: list_all2_lengthD dest!: typing_to_wellformed)
+
+
+  then have tfun_sub:
+    "[] \<turnstile> TFun (instantiate (map (instantiate \<delta>) ts) t) (instantiate (map (instantiate \<delta>) ts) u)
+        \<sqsubseteq> TFun (instantiate       \<delta> (instantiate ts t)) (instantiate       \<delta> (instantiate ts u))"
+    using assms
+    by (metis (mono_tags, lifting) list_all2_substitutivity specialisation_subtyping subty_tfun subtyping_refl typing_to_wellformed(1))
+
+  then show ?thesis
+    using assms
+    by (meson list_all2_substitutivity type_wellformed.simps(4) type_wellformed_pretty_def v_t_function)
 qed
 
 section {* matches lemmas *}
@@ -549,7 +736,7 @@ and     "\<Gamma> ! i = Some \<tau>"
 shows   "\<Xi> \<turnstile> (\<gamma> ! i) :v \<tau>"
 using assms by (auto dest: list_all2_nthD2
                      simp: matches_def
-                     intro: vval_typing_vval_typing_variant_vval_typing_record.intros)
+                     intro: vval_typing_vval_typing_record.intros)
 
 lemma matches_proj:
 assumes "list_all2 (kinding []) \<tau>s K"
@@ -587,11 +774,19 @@ lemma v_t_map_TPrimD:
   "\<Xi> \<turnstile>* vs :v map TPrim \<tau>s
     \<Longrightarrow> \<exists>lits. vs = map VPrim lits \<and> map lit_type lits = \<tau>s"
   unfolding vval_typing_all_def list_all2_map2
-  apply (induct rule: list_all2_induct, simp_all)
-  apply clarsimp
-  apply (erule vval_typing.cases, simp_all)
-  apply (rule exI[where x="x # xs" for x xs], simp)
-  done
+proof (induct rule: list_all2_induct)
+  case (Cons x xs y ys)
+  obtain l where l_def: "x = VPrim l"
+    using Cons by (auto elim: vval_typing.cases subtyping.cases)
+
+  obtain lits where lits_def: "xs = map VPrim lits \<and> map lit_type lits = ys"
+    using Cons by presburger
+
+  have "x # xs = map VPrim (l # lits) \<and> map lit_type (l # lits) = y # ys"
+    using Cons l_def lits_def by (auto elim: vval_typing.cases)
+
+  then show ?case by meson
+qed auto
 
 lemma eval_prim_preservation:
 assumes "prim_op_type p = (\<tau>s, \<tau>)"
@@ -605,7 +800,7 @@ assumes "list_all2 (kinding []) \<tau>s K"
 and     "proc_ctx_wellformed \<Xi>"
 and     "\<Xi> \<turnstile> \<gamma> matches (instantiate_ctx \<tau>s \<Gamma>)"
 and     "\<xi> matches \<Xi>"
-shows   "\<lbrakk> \<xi>, \<gamma> \<turnstile>  specialise \<tau>s e \<Down> v  ; \<Xi>, K, \<Gamma> \<turnstile>  e  : \<tau>  \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile>  v  :v instantiate \<tau>s \<tau>"
+shows   "\<lbrakk> \<xi>, \<gamma> \<turnstile>  specialise \<tau>s e \<Down> v  ; \<Xi>, K, \<Gamma> \<turnstile>  e  : \<tau> \<rbrakk> \<Longrightarrow>  \<Xi> \<turnstile>  v  :v instantiate \<tau>s \<tau>"
 and     "\<lbrakk> \<xi>, \<gamma> \<turnstile>* map (specialise \<tau>s) es \<Down> vs ; \<Xi>, K, \<Gamma> \<turnstile>* es : \<tau>s' \<rbrakk> \<Longrightarrow> \<Xi> \<turnstile>* vs :v map (instantiate \<tau>s) \<tau>s'"
 using assms proof (induct "specialise \<tau>s e"        v
                       and "map (specialise \<tau>s) es" vs
@@ -617,7 +812,7 @@ using assms proof (induct "specialise \<tau>s e"        v
                                                        intro: matches_proj
                                                        simp:  empty_length empty_def)
 next case v_sem_lit     then show ?case by ( case_tac e, simp_all
-                                           , fastforce intro: vval_typing_vval_typing_variant_vval_typing_record.intros)
+                                           , fastforce intro: vval_typing_vval_typing_record.intros)
 next case v_sem_prim    then show ?case by ( case_tac e, simp_all
                                            , fastforce intro: eval_prim_preservation)
 next case v_sem_cast    then show ?case by ( case_tac e, simp_all
@@ -637,42 +832,25 @@ next case (v_sem_con \<xi> \<gamma> x_spec x' ts_inst tag)
       "x_spec = specialise \<tau>s x"
       using v_sem_con.hyps Con
       by clarsimp+
-    moreover then obtain t ts'
+
+    moreover then obtain t
       where con_elims:
-        "\<tau> = TSum ts'"
+        "\<tau> = TSum ts"
         "\<Xi>, K, \<Gamma> \<turnstile> x : t"
+        "distinct (map fst ts)"
+        "K \<turnstile> TSum ts wellformed"
         "(tag, t, Unchecked) \<in> set ts"
-        "distinct (map fst ts')"
-        "map fst ts = map fst ts'"
-        "map (fst \<circ> snd) ts = map (fst \<circ> snd) ts'"
-        "list_all2 (\<lambda>x y. snd (snd x) \<le> snd (snd y)) ts ts'"
-        "K \<turnstile> TSum ts' wellformed"
-      using Con v_sem_con.prems by auto
-    ultimately have "\<Xi> \<turnstile> VSum tag x' :v TSum (map (\<lambda>(c, t, b). (c, instantiate \<tau>s t, b)) ts')"
+      using Con v_sem_con.prems
+      by auto
+    ultimately have "\<Xi> \<turnstile> VSum tag x' :v TSum (map (\<lambda>(c, t, b). (c, instantiate \<tau>s t, b)) ts)"
       using v_sem_con.hyps(2) v_sem_con.prems con_elims typing_simps
     proof (intro v_t_sum)
-      obtain i where tagelem_at:
-        "ts ! i = (tag, t, Unchecked)"
-        "i < length ts"
-        by (meson con_elims in_set_conv_nth)
-      then have
-        "fst (ts' ! i) = tag"
-        "fst (snd (ts' ! i)) = t"
-        "snd (snd (ts' ! i)) = Unchecked"
-        using con_elims
-        by (fastforce simp add: list_all2_eq list_all2_conv_all_nth order.antisym)+
-      then have
-        "ts' ! i = (tag, t, Unchecked)"
-        "i < length ts'"
-        using tagelem_at con_elims
-        by (metis length_map prod.collapse)+
-      then show "(tag, instantiate \<tau>s t, Unchecked) \<in> set (map (\<lambda>(c, t, b). (c, instantiate \<tau>s t, b)) ts')"
-        by (fastforce simp add: in_set_conv_nth simp del: set_map)
+      show "(tag, instantiate \<tau>s t, Unchecked) \<in> set (map (\<lambda>(c, t, b). (c, instantiate \<tau>s t, b)) ts)"
+        using con_elims image_iff by fastforce
     next
-      show "[] \<turnstile> TSum (map (\<lambda>(c, t, b). (c, instantiate \<tau>s t, b)) ts') wellformed"
+      show "[] \<turnstile> TSum (map (\<lambda>(c, t, b). (c, instantiate \<tau>s t, b)) ts) wellformed"
         using con_elims v_sem_con.prems
-        by (fastforce dest: list_all2_kinding_wellformedD intro: instantiate_wellformed
-            split: prod.splits variant_state.splits)
+        by (metis instantiate.simps(6) kinding_iff_wellformed(1) substitutivity_single)
     qed auto
     then show ?thesis
       using con_elims by auto
@@ -680,10 +858,10 @@ next case (v_sem_con \<xi> \<gamma> x_spec x' ts_inst tag)
 next case v_sem_member  then show ?case by ( case_tac e, simp_all
                                            , fastforce intro: vval_typing_record_nth)
 next case v_sem_unit    then show ?case by ( case_tac e, simp_all
-                                           , fastforce intro: vval_typing_vval_typing_variant_vval_typing_record.intros)
+                                           , fastforce intro: vval_typing_vval_typing_record.intros)
 next case v_sem_tuple   then show ?case by ( case_tac e, simp_all
                                            , fastforce intro: matches_split
-                                                              vval_typing_vval_typing_variant_vval_typing_record.intros)
+                                                              vval_typing_vval_typing_record.intros)
 next case v_sem_case_m  then show ?case by ( case_tac e, simp_all
                                            , fastforce intro: matches_split
                                                               matches_cons [simplified]
@@ -746,7 +924,7 @@ next
     have "\<Xi> \<turnstile> VSum tag v :v instantiate \<tau>s (TSum ts')"
       using v_sem_esac.hyps(2) v_sem_esac.prems esac_simps esac_elims
       by blast
-    then obtain \<tau>' k
+    then obtain \<tau>'
       where ih_elims:
         "\<Xi> \<turnstile> v :v instantiate \<tau>s \<tau>'"
         "(tag, instantiate \<tau>s \<tau>', Unchecked) \<in> set (map (\<lambda>(c, t, b). (c, instantiate \<tau>s t, b)) ts')"
@@ -768,7 +946,7 @@ next case v_sem_if      then show ?case by ( case_tac e, simp_all
                                            , fastforce intro:  matches_split
                                                        split:  if_splits)
 next case v_sem_struct  then show ?case by ( case_tac e, simp_all
-                                           , fastforce intro: vval_typing_vval_typing_variant_vval_typing_record.intros
+                                           , fastforce intro: vval_typing_vval_typing_record.intros
                                                               vval_typing_all_record [ where ts = "map f ts" for f ts
                                                                                      , simplified])
 next
@@ -806,12 +984,12 @@ next
     moreover then have all_inst_ts:
       "\<Xi> \<turnstile>* fs :vr map (\<lambda>(n, t, b). (n, instantiate \<tau>s t, b)) ts"
       "distinct (map fst ts)"
-      by (fastforce elim!: v_t_recordE)+
+      by (fastforce)+
     moreover then have "\<And>t' b'. distinct (map fst (ts[f := (n, t', b')]))"
       by (simp add: map_fst_update typing_elims)
     ultimately have "\<Xi> \<turnstile> VRecord fs :v TRecord (map (\<lambda>(n, t, b). (n, instantiate \<tau>s t, b)) (ts[f := (n, t, taken)])) s"
       using typing_elims v_sem_take.prems
-      by (fastforce simp add: map_update intro: substitutivity vval_typing_vval_typing_variant_vval_typing_record.intros vval_typing_record_take)
+      by (fastforce simp add: map_update intro: substitutivity vval_typing_vval_typing_record.intros vval_typing_record_take)
     then show ?thesis
       using v_sem_take.prems matchsplit_lemmas typing_elims spec_simps all_inst_ts
       by (fastforce intro!: v_sem_take.hyps(4) simp add: matches_Cons vval_typing_record_nth)
@@ -853,7 +1031,7 @@ next
 
     show "\<Xi> \<turnstile> VRecord (fs[f := ea']) :v instantiate \<tau>s \<tau>"
       using v_sem_put assms1 typingelims IHresults instvrecordelims
-    proof (simp add: map_update, intro vval_typing_vval_typing_variant_vval_typing_record.intros vval_typing_record_put)
+    proof (simp add: map_update, intro vval_typing_vval_typing_record.intros vval_typing_record_put)
       show "[] \<turnstile> instantiate \<tau>s t :\<kappa> k"
         using v_sem_put.prems typingelims
         by (blast intro: substitutivity)
@@ -869,47 +1047,86 @@ next case v_sem_split   then show ?case by ( case_tac e, simp_all
                                            , fastforce intro!: matches_cons
                                                        intro:  matches_split)
 next case (v_sem_app \<xi> \<gamma> x ea ts y a r e \<tau>s K \<tau> \<Gamma>)
-note IH1  = this(2)
-and  IH2  = this(4)
-and  IH3  = this(6)
-and  rest = this(1,3,5,7-)
-from rest show ?case
-  apply (case_tac e, simp_all)
-  apply (clarsimp)
-  apply (fastforce elim!: typing_appE
-                   dest!: IH1 [OF _ _ _ _ matches_split(1)]
-                          IH2 [OF _ _ _ _ matches_split(2)]
-                   intro: IH3
-                   simp:  matches_def
-                          instantiate_ctx_def).
-next case v_sem_abs_app
-note IH1  = this(2)
-and  IH2  = this(4)
-and  rest = this(1,3,5-)
-from rest show ?case
-  apply (case_tac e, simp_all)
-  apply (clarsimp elim!: typing_appE)
-  apply (frule(7) IH1 [OF _ _ _ _ matches_split(1)])
-  apply (frule(7) IH2 [OF _ _ _ _ matches_split(2)])
-  apply (fastforce intro: proc_env_matches_abstract).
+  obtain efun earg where e_def: "e = App efun earg"
+      "x = specialise \<tau>s efun"
+      "y = specialise \<tau>s earg"
+    using v_sem_app by (cases e, auto)
+
+  obtain \<Gamma>1 \<Gamma>2 targ where app_elims:
+    "K \<turnstile> \<Gamma> \<leadsto> \<Gamma>1 | \<Gamma>2"
+    "\<Xi>, K, \<Gamma>1 \<turnstile> efun : TFun targ \<tau>"
+    "\<Xi>, K, \<Gamma>2 \<turnstile> earg : targ"
+    using v_sem_app e_def by blast
+
+  have vfun_ty: "\<Xi> \<turnstile> VFunction ea ts :v instantiate \<tau>s (TFun targ \<tau>)"
+    using app_elims e_def v_sem_app matches_split
+    by fast
+
+  have varg_ty: "\<Xi> \<turnstile> a :v instantiate \<tau>s targ"
+    using app_elims e_def v_sem_app matches_split
+    by fast
+
+  obtain Kfun t u where vfun_ty_elims: "\<Xi>, Kfun, [Some t] \<turnstile> ea : u"
+       "type_wellformed (length Kfun) t"
+       "list_all2 (kinding []) ts Kfun"
+       "[] \<turnstile> TFun (instantiate ts t) (instantiate ts u) \<sqsubseteq> TFun (instantiate \<tau>s targ) (instantiate \<tau>s \<tau>)"
+    using vfun_ty by (auto elim: vval_typing.cases)
+
+  have vres_ty_sub: "\<Xi> \<turnstile> r :v instantiate ts u"
+    using vfun_ty_elims v_sem_app(6)
+    using matches_cons' matches_empty subtyping_simps(4) v_sem_app.prems(3) v_sem_app.prems(5) value_subtyping(1) varg_ty by fastforce
+
+  show ?case
+    using app_elims e_def v_sem_app vfun_ty_elims vres_ty_sub
+    by (metis subtyping_simps(4) value_subtyping(1))
+
+next case (v_sem_abs_app \<xi> \<gamma> x f ts y a r)
+  obtain efun earg where e_def: "e = App efun earg"
+      "x = specialise \<tau>s efun"
+      "y = specialise \<tau>s earg"
+    using v_sem_abs_app by (cases e, auto)
+
+  obtain \<Gamma>1 \<Gamma>2 targ where app_elims:
+    "K \<turnstile> \<Gamma> \<leadsto> \<Gamma>1 | \<Gamma>2"
+    "\<Xi>, K, \<Gamma>1 \<turnstile> efun : TFun targ \<tau>"
+    "\<Xi>, K, \<Gamma>2 \<turnstile> earg : targ"
+    using v_sem_abs_app e_def by blast
+
+  have vafun_ty: "\<Xi> \<turnstile> VAFunction f ts :v instantiate \<tau>s (TFun targ \<tau>)"
+    using app_elims e_def v_sem_abs_app matches_split
+    by fast
+
+  have varg_ty: "\<Xi> \<turnstile> a :v instantiate \<tau>s targ"
+    using app_elims e_def v_sem_abs_app matches_split
+    by fast
+
+  obtain ks t u t' u' where vafun_ty_elims:
+      "instantiate \<tau>s (TFun targ \<tau>) = TFun t' u'"
+      "\<Xi> f = (ks, t, u)"
+      "list_all2 (kinding []) ts ks"
+      "ks \<turnstile> TFun t u wellformed"
+      "[] \<turnstile> TFun (instantiate ts t) (instantiate ts u) \<sqsubseteq> TFun t' u'"
+    using vafun_ty by (auto elim: vval_typing.cases)
+
+  have vres_ty_sub: "\<Xi> \<turnstile> r :v instantiate ts u"
+    using vafun_ty_elims varg_ty v_sem_abs_app
+    using subtyping_simps(4) value_subtyping(1)  instantiate.simps(4) proc_env_matches_abstract
+    by metis
+
+  show ?case
+    using app_elims e_def v_sem_abs_app vafun_ty_elims vres_ty_sub
+    by (metis instantiate.simps(4) subtyping_simps(4) value_subtyping(1))
+
 next case v_sem_all_empty then show ?case by ( case_tac es, simp_all
                                              , fastforce simp: vval_typing_all_def)
 next case v_sem_all_cons  then show ?case by ( case_tac es, simp_all
                                              , fastforce simp: vval_typing_all_def
                                                          dest: matches_split)
 next
-  case (v_sem_promote \<xi> \<gamma> ea ea' t)
+  case (v_sem_promote \<Xi> \<xi> \<gamma> ea ea' t)
   then show ?case
-    apply clarsimp
-    apply (drule meta_spec)+
-    apply (drule meta_mp)
-    defer
-     apply (drule meta_mp, force)
-     apply (drule meta_mp, force)
-     apply (drule meta_mp, force)
-     apply force
-
-    sorry
+    using value_subtyping(1) specialisation(1) typing_promoteE instantiate_ctx_nothing instantiate_nothing list.ctr_transfer(1) specialise_nothing
+    by (metis)
 qed
 
 (* TODO:
@@ -931,6 +1148,7 @@ function monoexpr :: "'f expr \<Rightarrow> ('f \<times> type list) expr" where
 | "monoexpr (Unit)            = Unit"
 | "monoexpr (Cast t e)        = Cast t (monoexpr e)"
 | "monoexpr (Lit v)           = Lit v"
+| "monoexpr (SLit v)          = SLit v"
 | "monoexpr (Tuple a b)       = Tuple (monoexpr a) (monoexpr b)"
 | "monoexpr (Put e f e')      = Put (monoexpr e) f (monoexpr e')"
 | "monoexpr (Let e e')        = Let (monoexpr e) (monoexpr e')"
@@ -941,6 +1159,7 @@ function monoexpr :: "'f expr \<Rightarrow> ('f \<times> type list) expr" where
 | "monoexpr (Take e f e')     = Take (monoexpr e) f (monoexpr e')"
 | "monoexpr (Split v va)      = Split (monoexpr v) (monoexpr va)"
 | "monoexpr (Promote t x)     = Promote t (monoexpr x)"
+
              by (case_tac x, auto)
 termination by (relation "measure expr_size", (simp add: order_sum_list)+)
 
@@ -958,7 +1177,6 @@ where "monoval (VPrim lit) = VPrim lit"
 definition monoprog :: "('f, 'a) vabsfuns \<Rightarrow> (('f \<times> type list), 'a) vabsfuns \<Rightarrow> bool"
 where "monoprog \<xi> \<xi>' \<equiv> \<forall>f \<tau>s. (\<forall>v v'. \<xi> f v v' \<longleftrightarrow> \<xi>' (f, \<tau>s) (monoval v) (monoval v'))"
 
-
 lemma member_nth_map: "f < length fs \<Longrightarrow> \<xi>', map monoval \<gamma> \<turnstile> Member (monoexpr e) f \<Down> monoval (fs ! f) =  \<xi>' , map monoval \<gamma> \<turnstile> Member (monoexpr e) f \<Down> (map monoval fs) ! f"
 by (subst nth_map, simp_all)
 thm v_sem_prim
@@ -968,40 +1186,39 @@ by (force dest: sym intro: v_sem_prim)
 
 lemma monoval_vprim [simp]: "monoval \<circ> VPrim = VPrim" by (rule ext, simp)
 
-lemma eval_prim_type_change:
-assumes "(eval_prim :: prim_op \<Rightarrow> ('f1, 'a1) vval list \<Rightarrow> ('f1, 'a1) vval) p (map VPrim lits) = VPrim l"
-shows "(eval_prim :: prim_op \<Rightarrow> ('f2, 'a2) vval list \<Rightarrow> ('f2, 'a2) vval) p (map VPrim lits) = VPrim l"
-proof -
-have helper: "(\<lambda>vv. case vv of VPrim v \<Rightarrow> v | _ \<Rightarrow> LBool False) \<circ> VPrim = id" by (rule ext, simp)
-then show ?thesis using assms by (simp add: eval_prim_def helper)
-qed
-
 lemma mono_correct:
 assumes "\<xi> matches \<Xi>"
 and     "proc_ctx_wellformed \<Xi>"
 and     "\<Xi> \<turnstile> \<gamma> matches \<Gamma>"
 and     "monoprog \<xi> \<xi>'"
 shows   "\<xi>, \<gamma> \<turnstile> e \<Down> e' \<Longrightarrow>  \<Xi>, [], \<Gamma> \<turnstile> e : \<tau>    \<Longrightarrow> \<xi>', map monoval \<gamma> \<turnstile> monoexpr e \<Down> monoval e'"
-and     "\<xi>, \<gamma> \<turnstile>* es \<Down> es' \<Longrightarrow> \<Xi>, [], \<Gamma> \<turnstile>* es : \<tau>s \<Longrightarrow> \<xi>', map monoval \<gamma> \<turnstile>* map monoexpr es \<Down> map monoval es'"
+ and     "\<xi>, \<gamma> \<turnstile>* es \<Down> es' \<Longrightarrow> \<Xi>, [], \<Gamma> \<turnstile>* es : \<tau>s \<Longrightarrow> \<xi>', map monoval \<gamma> \<turnstile>* map monoexpr es \<Down> map monoval es'"
 using assms proof (induct \<xi> \<gamma> e e'
                       and \<xi> \<gamma> es es'
                arbitrary: \<tau> \<Gamma>
                       and \<tau>s \<Gamma>
                     rule: v_sem_v_sem_all.inducts)
-case v_sem_app
+  case (v_sem_app \<xi> \<gamma> x e ts y a r)
 note IH1 = this(2)
 and  IH2 = this(4)
 and  IH3 = this(6)
 and  rest = this(1,3,5,7-)
-then show ?case
+  then show ?case
   apply (clarsimp)
   apply (erule typing_appE)
   apply (rule, erule(5) IH1 [OF _ _ _ matches_split'(1), simplified], erule(5) IH2 [OF _ _ _ matches_split'(2), simplified])
   apply (simp)
   apply (frule(5) preservation(1) [where \<tau>s = "[]" and K = "[]", OF _ _ matches_split'(1), simplified])
-  apply (frule(5) preservation(1) [where \<tau>s = "[]" and K = "[]", OF _ _ matches_split'(2), simplified])
-  apply (auto elim!: v_t_funE
-              intro: IH3 [simplified] specialisation
+    apply (frule(5) preservation(1) [where \<tau>s = "[]" and K = "[]", OF _ _ matches_split'(2), simplified])
+
+
+    apply (erule v_t_funE)
+    apply (rule_tac V="\<Xi> \<turnstile> a :v instantiate ts t" in revcut_rl)
+      apply (rule value_subtyping)
+       apply assumption
+      apply (auto elim: subtyping.cases)
+    apply (rule IH3[simplified])
+    apply (auto intro: specialisation
               simp:  matches_def instantiate_ctx_def)
 done
 next case v_sem_abs_app
@@ -1051,7 +1268,7 @@ next case (v_sem_take \<xi> \<gamma> x fs f e e')
 
   have "\<Xi> \<turnstile> VRecord fs :v TRecord (ts[f := (n, t, taken)]) s"
     using takeelims ts_v_sem_lemmas
-    by (fastforce intro: vval_typing_vval_typing_variant_vval_typing_record.intros vval_typing_record_take simp add: map_fst_update)
+    by (fastforce intro: vval_typing_vval_typing_record.intros vval_typing_record_take simp add: map_fst_update)
   moreover have "\<Xi> \<turnstile> fs ! f :v t"
     using takeelims ts_v_sem_lemmas vval_typing_record_nth by blast
   ultimately have "\<xi>' , map monoval fs ! f # VRecord (map monoval fs) # map monoval \<gamma> \<turnstile> monoexpr e \<Down> monoval e'"
@@ -1097,7 +1314,7 @@ from rest show ?case
   apply (rule v_sem_prim')
   apply (clarsimp)
   apply (erule(4) IH)
-  apply (force intro: eval_prim_type_change)
+    apply (force intro: eval_prim_type_change)
 done
 next case v_sem_struct then show ?case by (fastforce intro!: v_sem_v_sem_all.v_sem_struct)
 next case v_sem_case_m then show ?case
@@ -1154,7 +1371,14 @@ next case v_sem_put then show ?case
   apply (frule(1) matches_split'(1))
   apply (frule(1) matches_split'(2))
   apply (fastforce simp: map_update intro: v_sem_v_sem_all.v_sem_put)
-done
+    done
+next case (v_sem_promote \<xi> \<gamma> e e' t e'' t')
+  have eval_orig: "\<xi>' , map monoval \<gamma> \<turnstile> monoexpr e \<Down> monoval e'"
+    using v_sem_promote.hyps(2) v_sem_promote.prems(1) v_sem_promote.prems(2) v_sem_promote.prems(3) v_sem_promote.prems(4) v_sem_promote.prems(5) by auto
+  then show ?case
+    apply (clarsimp)
+    apply (rule v_sem_v_sem_all.v_sem_promote[where e' = "monoval _"])
+    using eval_orig by assumption
 qed
 
 end


### PR DESCRIPTION
Add subtyping to formalisation.
The following files in cogent/isa have been updated with subtyping: Cogent, ValueSemantics, UpdateSemantics, and Correspondence. These files go through with no errors.

The following files fail on master and in this branch: Mono, Mono_Tac, CogentHelper, and Subtyping. The files in `shallow/` do not fail immediately, but they haven't been updated with subtyping, so presumably the tactics don't work on programs.