### PR TITLE
compiler: individuate the types of function names in core

### DIFF
--- a/cogent/Main.hs
+++ b/cogent/Main.hs
@@ -827,7 +827,7 @@ parseArgs args = case getOpt' Permute options args of
       when cp $ do
         putProgressLn "Generating C-refinement proofs..."
         ent <- T.forM __cogent_entry_funcs $ (liftA parseEntryFuncs) . readFile  -- a simple parser
-        let corresProofThy = corresProof thy inputc (map SY.CoreFunName confns) (map CoreFunName <$> ent) log
+        let corresProofThy = corresProof thy inputc (map SY.CoreFunName confns) (map SY.CoreFunName <$> ent) log
         writeFileMsg cpfile
         output cpfile $ flip LJ.hPutDoc corresProofThy
 

--- a/cogent/Main.hs
+++ b/cogent/Main.hs
@@ -29,6 +29,7 @@ module Main where
 
 import Cogent.C.Compile                as CG (printCTable, printATM)
 import Cogent.CodeGen                  as CG (cgen)
+import Cogent.Common.Syntax            as SY (CoreFunName(..))
 import Cogent.Compiler
 import Cogent.Core                     as CC (isConFun, getDefinitionId, untypeD)  -- FIXME: zilinc
 import Cogent.Desugar                  as DS (desugar)
@@ -826,7 +827,7 @@ parseArgs args = case getOpt' Permute options args of
       when cp $ do
         putProgressLn "Generating C-refinement proofs..."
         ent <- T.forM __cogent_entry_funcs $ (liftA parseEntryFuncs) . readFile  -- a simple parser
-        let corresProofThy = corresProof thy inputc confns ent log
+        let corresProofThy = corresProof thy inputc (map SY.CoreFunName confns) (map CoreFunName <$> ent) log
         writeFileMsg cpfile
         output cpfile $ flip LJ.hPutDoc corresProofThy
 

--- a/cogent/src/Cogent/C/Compile.hs
+++ b/cogent/src/Cogent/C/Compile.hs
@@ -771,20 +771,20 @@ genExpr mv (TE t (Variable v)) = do  -- NOTE: this `v' could be a higher-order f
 
 genExpr mv (TE t (Fun f _ _)) = do  -- it is a function identifier
   t' <- genType t
-  maybeAssign t' mv (variable $ funEnum f) M.empty
+  maybeAssign t' mv (variable $ funEnum (coreFunName f)) M.empty
 
 genExpr mv (TE t (App e1@(TE _ (Fun f _ MacroCall)) e2)) | __cogent_ffncall_as_macro = do  -- first-order function application
   (e2',e2decl,e2stm,e2p) <- genExpr_ e2
   t' <- genType t
   (v,vdecl,vstm) <- maybeDecl mv t'
-  let call = [CBIStmt $ CAssignFnCall Nothing (variable $ funMacro f) [variable v, e2']]
+  let call = [CBIStmt $ CAssignFnCall Nothing (variable $ funMacro (coreFunName f)) [variable v, e2']]
   recycleVars e2p
   return (variable v, e2decl ++ vdecl, e2stm ++ vstm ++ call, M.empty)
 
 genExpr mv (TE t (App e1@(TE _ (Fun f _ _)) e2)) = do  -- first-order function application
   (e2',e2decl,e2stm,e2p) <- genExpr_ e2
   t' <- genType t
-  (v,adecl,astm,vp) <- maybeAssign t' mv (CEFnCall (variable f) [e2']) e2p
+  (v,adecl,astm,vp) <- maybeAssign t' mv (CEFnCall (variable (coreFunName f)) [e2']) e2p
   return (v, e2decl++adecl, e2stm++astm, vp)
 
 genExpr mv (TE t (App e1 e2)) | __cogent_ffncall_as_macro = do

--- a/cogent/src/Cogent/Common/Syntax.hs
+++ b/cogent/src/Cogent/Common/Syntax.hs
@@ -16,9 +16,26 @@ type RepName     = String
 type FieldName   = String
 type TagName     = String
 type FunName     = String
+type ConstName   = String
 type VarName     = String
 type TyVarName   = String
 type TypeName    = String
+-- one of these was used incorrectly somewhere, find and fix
+
+newtype CoreFunName = CoreFunName { coreFunName :: String }
+  deriving (Eq, Show, Ord, Data)
+
+coreFunNameToIsabelleName :: CoreFunName -> String
+coreFunNameToIsabelleName (CoreFunName s) = s
+
+funNameToCoreFunName :: FunName -> CoreFunName
+funNameToCoreFunName = CoreFunName
+
+unsafeNameToCoreFunName :: String -> CoreFunName
+unsafeNameToCoreFunName = CoreFunName
+
+unsafeIsabelleNameToCoreFunName :: String -> CoreFunName
+unsafeIsabelleNameToCoreFunName = CoreFunName
 
 type FieldIndex = Int
 type ArrayIndex = Word32

--- a/cogent/src/Cogent/Common/Syntax.hs
+++ b/cogent/src/Cogent/Common/Syntax.hs
@@ -20,7 +20,6 @@ type ConstName   = String
 type VarName     = String
 type TyVarName   = String
 type TypeName    = String
--- one of these was used incorrectly somewhere, find and fix
 
 newtype CoreFunName = CoreFunName { coreFunName :: String }
   deriving (Eq, Show, Ord, Data)

--- a/cogent/src/Cogent/Common/Syntax.hs
+++ b/cogent/src/Cogent/Common/Syntax.hs
@@ -22,7 +22,7 @@ type TyVarName   = String
 type TypeName    = String
 
 newtype CoreFunName = CoreFunName { coreFunName :: String }
-  deriving (Eq, Show, Ord, Data)
+  deriving (Eq, Show, Ord)
 
 coreFunNameToIsabelleName :: CoreFunName -> String
 coreFunNameToIsabelleName (CoreFunName s) = s

--- a/cogent/src/Cogent/Core.hs
+++ b/cogent/src/Cogent/Core.hs
@@ -95,7 +95,7 @@ data FunNote = NoInline | InlineMe | MacroCall | InlinePlease  -- order is impor
 
 data Expr t v a e
   = Variable (Fin v, a)
-  | Fun FunName [Type t] FunNote  -- here do we want to keep partial application and infer again? / zilinc
+  | Fun CoreFunName [Type t] FunNote  -- here do we want to keep partial application and infer again? / zilinc
   | Op Op [e t v a]
   | App (e t v a) (e t v a)
   | Con TagName (e t v a) (Type t)
@@ -176,9 +176,9 @@ getTypeVarNum (TypeDef _ tvs _    ) = Nat.toInt $ Vec.length tvs
 isDefinitionId :: String -> Definition e a -> Bool
 isDefinitionId n d = n == getDefinitionId d
 
-isFuncId :: String -> Definition e a -> Bool
-isFuncId n (FunDef  _ fn _ _ _ _) = n == fn
-isFuncId n (AbsDecl _ fn _ _ _  ) = n == fn
+isFuncId :: CoreFunName -> Definition e a -> Bool
+isFuncId n (FunDef  _ fn _ _ _ _) = coreFunName n == fn
+isFuncId n (AbsDecl _ fn _ _ _  ) = coreFunName n == fn
 isFuncId _ _ = False
 
 isAbsFun :: Definition e a -> Bool
@@ -388,7 +388,7 @@ instance (Pretty a, Prec (e t v a), Pretty (e t v a), Pretty (e t ('Suc v) a), P
   pretty (Singleton e) = keyword "singleton" <+> parens (pretty e)
 #endif
   pretty (Variable x) = pretty (snd x) L.<> angles (prettyV $ fst x)
-  pretty (Fun fn ins nt) = pretty nt L.<> funname fn <+> pretty ins
+  pretty (Fun fn ins nt) = pretty nt L.<> funname (coreFunName fn) <+> pretty ins
   pretty (App a b) = prettyPrec 2 a <+> prettyPrec 1 b
   pretty (Let a e1 e2) = align (keyword "let" <+> pretty a <+> symbol "=" <+> pretty e1 L.<$>
                                 keyword "in" <+> pretty e2)

--- a/cogent/src/Cogent/Desugar.hs
+++ b/cogent/src/Cogent/Desugar.hs
@@ -542,7 +542,7 @@ desugarExpr (B.TE _ (S.Match e vs alts) l) = do
   E <$> (LetBang vs' v <$> desugarExpr e <*> pure e')
 desugarExpr (B.TE _ (S.TypeApp v ts note) _) = do
   pragmas <- view _3
-  E <$> (Fun v <$> mapM desugarType (map fromJust ts) <*> pure (pragmaToNote pragmas v $ desugarNote note))  -- FIXME: fromJust
+  E <$> (Fun (funNameToCoreFunName v) <$> mapM desugarType (map fromJust ts) <*> pure (pragmaToNote pragmas v $ desugarNote note))  -- FIXME: fromJust
 desugarExpr (B.TE t (S.Con c [e]) _) = do
   t'@(TSum ts) <- desugarType t
   e' <- desugarExpr e

--- a/cogent/src/Cogent/Glue.hs
+++ b/cogent/src/Cogent/Glue.hs
@@ -395,7 +395,7 @@ transFuncId :: CS.Definition -> GlMono t CS.Definition
 transFuncId (CS.FuncDef (CS.Func dcsp (CS.AntiId fn loc2) decl ps body loc1) loc0) =
   view (inst._2) >>= \idx -> do
     (fnName, _) <- lift . lift $ genFuncId fn loc2
-    return $ CS.FuncDef (CS.Func dcsp (CS.Id (toCName $ MN.monoName (unsafeNameToCoreFunName fn) idx) loc2) decl ps body loc1) loc0
+    return $ CS.FuncDef (CS.Func dcsp (CS.Id (toCName $ MN.monoName (unsafeNameToCoreFunName fnName) idx) loc2) decl ps body loc1) loc0
 transFuncId d = return d
 
 genFuncId :: String -> SrcLoc -> GlFile (FunName, [Maybe SF.LocType])

--- a/cogent/src/Cogent/Haskell/Shallow.hs
+++ b/cogent/src/Cogent/Haskell/Shallow.hs
@@ -498,7 +498,7 @@ shallowExpr (TE _ (CC.Variable (_,v))) = do
              Just v' -> v'
   pure . mkVarE . mkName $ snm v'
 
-shallowExpr (TE _ (CC.Fun fn ts _)) = pure $ mkVarE $ mkName (snm fn)  -- only prints the fun name
+shallowExpr (TE _ (CC.Fun fn ts _)) = pure $ mkVarE $ mkName $ snm $ coreFunName fn  -- only prints the fun name
 
 shallowExpr (TE _ (CC.Op opr es)) = shallowPrimOp <$> pure opr <*> (mapM shallowExpr es)
 

--- a/cogent/src/Cogent/Inference.hs
+++ b/cogent/src/Cogent/Inference.hs
@@ -206,8 +206,8 @@ useVariable v = TC $ do ret <- (`at` v) <$> get
                             unless ok $ modify (\s -> update s v Nothing)
                             return ret
 
-funType :: FunName -> TC t v (Maybe FunctionType)
-funType v = TC $ (M.lookup v . snd) <$> ask
+funType :: CoreFunName -> TC t v (Maybe FunctionType)
+funType v = TC $ (M.lookup (coreFunName v) . snd) <$> ask
 
 runTC :: TC t v a -> (Vec t Kind, Map FunName FunctionType) -> Vec v (Maybe (Type t))
       -> Either String (Vec v (Maybe (Type t)), a)

--- a/cogent/src/Cogent/Isabelle/Deep.hs
+++ b/cogent/src/Cogent/Isabelle/Deep.hs
@@ -129,9 +129,11 @@ deepPrimOp CS.Complement t = mkApp (mkId "Complement") [deepNumType t]
 deepExpr :: (Pretty a) => NameMod -> TypeAbbrevs -> [Definition TypedExpr a] -> TypedExpr t v a -> Term
 deepExpr mod ta defs (TE _ (Variable v)) = mkApp (mkId "Var") [deepIndex (fst v)]
 deepExpr mod ta defs (TE _ (Fun fn ts _))
-  | concreteFun fn = mkApp (mkId "Fun")  [mkId (mod fn), mkList (map (deepType mod ta) ts)]
-  | otherwise      = mkApp (mkId "AFun") [mkString fn, mkList (map (deepType mod ta) ts)]
-  where concreteFun f = any (\def -> isFuncId f def && case def of FunDef{} -> True; _ -> False) defs
+  | concreteFun fn = mkApp (mkId "Fun")  [mkId (mod (coreFunNameToIsabelleName fn)), mkList (map (deepType mod ta) ts)]
+  | otherwise      = mkApp (mkId "AFun") [mkString (coreFunNameToIsabelleName fn), mkList (map (deepType mod ta) ts)]
+  where
+    concreteFun :: CoreFunName -> Bool
+    concreteFun f = any (\def -> isFuncId f def && case def of FunDef{} -> True; _ -> False) defs
 deepExpr mod ta defs (TE _ (Op opr es))
   = mkApp (mkId "Prim") [deepPrimOp opr (let TPrim pt = exprType $ head es in pt),
                          mkList (map (deepExpr mod ta defs) es)]

--- a/cogent/src/Cogent/Isabelle/GraphGen.hs
+++ b/cogent/src/Cogent/Isabelle/GraphGen.hs
@@ -48,7 +48,7 @@ data NextNode
 data GraphNode
     = GBasic NextNode [(String, GTyp, GExpr)]
     | GCond NextNode NextNode GExpr
-    | GCall NextNode CS.FunName [GExpr] [(String, GTyp)]
+    | GCall NextNode CS.CoreFunName [GExpr] [(String, GTyp)]
     deriving (Show)
 
 data FunctionGraph = FunctionGraph CS.FunName [(String, GTyp)] [(String, GTyp)] Graph
@@ -595,7 +595,7 @@ prettyGraph (Graph []) = ""
 prettyNode :: GraphNode -> String
 prettyNode (GBasic nn es) = "Basic " ++ prettyNN nn ++ " " ++ show(Prelude.length es) ++ " " ++ prettyBindings es
 prettyNode (GCond n1 n2 e) = "Cond " ++ prettyNN n1 ++ " " ++ prettyNN n2 ++ " " ++ prettyE e
-prettyNode (GCall nn s gs vs) = "Call " ++ prettyNN nn ++ " " ++ prettyFName s ++ " " ++ prettyList prettyE gs ++ "  " ++ prettyVars vs
+prettyNode (GCall nn s gs vs) = "Call " ++ prettyNN nn ++ " " ++ prettyFName (CS.coreFunName s) ++ " " ++ prettyList prettyE gs ++ "  " ++ prettyVars vs
 
 prettyFName :: CS.FunName -> String
 prettyFName s = "Cogent." ++ s

--- a/cogent/src/Cogent/Isabelle/ProofGen.hs
+++ b/cogent/src/Cogent/Isabelle/ProofGen.hs
@@ -254,7 +254,7 @@ typing xi k (EE t (Variable i) env) = tacSequence [
   return [simp]                           -- i < length Γ
   ]
 
-typing xi k (EE t' (Fun f ts _) env) = case findfun f xi of
+typing xi k (EE t' (Fun f ts _) env) = case findfun (coreFunNameToIsabelleName f) xi of
     AbsDecl _ _ ks' t u ->
       let ks = fmap snd ks' in tacSequence [
         return [rule "typing_afun'"],  -- Ξ, K, Γ ⊢ AFun f ts : t' if
@@ -262,7 +262,7 @@ typing xi k (EE t' (Fun f ts _) env) = case findfun f xi of
            mod <- use nameMod
            let unabbrev | M.null (fst ta) = ""
                         | otherwise = "[unfolded " ++ typeAbbrevBucketName ++ "]"
-           return [simp_add ["\\<Xi>_def", mod f ++ "_type_def" ++ unabbrev]],  -- Ξ f = (K', t, u)
+           return [simp_add ["\\<Xi>_def", mod (coreFunNameToIsabelleName f) ++ "_type_def" ++ unabbrev]],  -- Ξ f = (K', t, u)
         allKindCorrect k ts ks,    -- list_all2 (kinding K) ts K'
         return [simp],             -- instantiate ts (TFun t u)
         wellformed ks (TFun t u),  -- K' ⊢ TFun t u wellformed
@@ -275,7 +275,7 @@ typing xi k (EE t' (Fun f ts _) env) = case findfun f xi of
         do ta <- use tsTypeAbbrevs
            mod <- use nameMod
            let unabbrev | M.null (fst ta) = "" | otherwise = " " ++ typeAbbrevBucketName
-           return [rule (fn_proof (mod f) unabbrev)],  -- Ξ, K', [Some t] ⊢ f : u
+           return [rule (fn_proof (mod (coreFunNameToIsabelleName f)) unabbrev)],  -- Ξ, K', [Some t] ⊢ f : u
         allKindCorrect k ts ks,  -- list_all2 (kinding K) ts K'
         return [simp],           -- t' = instantiate ts (TFun t u)
         wellformed ks t,         -- K' ⊢ t wellformed

--- a/cogent/src/Cogent/Isabelle/Shallow.hs
+++ b/cogent/src/Cogent/Isabelle/Shallow.hs
@@ -187,7 +187,7 @@ findTypeSyn t = findType t >>= \(TCon nm _ _) -> pure nm
 
 shallowExpr :: TypedExpr t v VarName -> SG Term
 shallowExpr (TE _ (Variable (_,v))) = pure $ mkId (snm v)
-shallowExpr (TE _ (Fun fn ts _)) = pure $ mkId (snm fn)  -- only prints the fun name
+shallowExpr (TE _ (Fun fn ts _)) = pure $ mkId $ snm $ coreFunNameToIsabelleName fn  -- only prints the fun name
 shallowExpr (TE _ (Op opr es)) = shallowPrimOp <$> pure opr <*> (mapM shallowExpr es)
 shallowExpr (TE _ (App f arg)) = mkApp <$> shallowExpr f <*> (mapM shallowExpr [arg])
 shallowExpr (TE t (Con cn e _))  = do

--- a/cogent/src/Cogent/Mono.hs
+++ b/cogent/src/Cogent/Mono.hs
@@ -134,19 +134,19 @@ monoDefinitionInsts d [] =
          censor (first3 $ (("Cannot monomorphise definition `" ++ getDefinitionId d ++ "'") :)) (return ())  -- shouldn't happen if __cogent_entry_funcs /= Nothing
 monoDefinitionInsts d is = flip mapM_ is $ monoDefinitionInst d
 
-monoName :: String -> Maybe Int -> String
-monoName n Nothing  = n
-monoName n (Just i) = n ++ "_" ++ show i
+monoName :: CoreFunName -> Maybe Int -> String
+monoName n Nothing  = coreFunNameToIsabelleName n
+monoName n (Just i) = coreFunNameToIsabelleName n ++ "_" ++ show i
 
 -- given one instance
 monoDefinitionInst :: Definition TypedExpr VarName -> Instance -> Mono ()
 monoDefinitionInst (FunDef attr fn tvs t rt e) i = do
   idx <- if P.null i then return Nothing else M.lookup i . fromJust . M.lookup fn . fst <$> get
-  d' <- Mono $ local (const i) (runMono $ FunDef attr (monoName fn idx) Nil <$> monoType t <*> monoType rt <*> monoExpr e)
+  d' <- Mono $ local (const i) (runMono $ FunDef attr (monoName (unsafeIsabelleNameToCoreFunName fn) idx) Nil <$> monoType t <*> monoType rt <*> monoExpr e)
   censor (second3 $ (d':)) (return ())
 monoDefinitionInst (AbsDecl attr fn tvs t rt) i = do
   idx <- if P.null i then return Nothing else M.lookup i . fromJust . M.lookup fn . fst <$> get
-  d' <- Mono $ local (const i) (runMono $ AbsDecl attr (monoName fn idx) Nil <$> monoType t <*> monoType rt)
+  d' <- Mono $ local (const i) (runMono $ AbsDecl attr (monoName (unsafeIsabelleNameToCoreFunName fn) idx) Nil <$> monoType t <*> monoType rt)
   censor (second3 $ (d':)) (return ())
 monoDefinitionInst (TypeDef tn tvs t) i = __impossible "monoDefinitionInst"
 
@@ -158,12 +158,12 @@ monoExpr :: TypedExpr t v VarName -> Mono (TypedExpr 'Zero v VarName)
 monoExpr (TE t e) = TE <$> monoType t <*> monoExpr' e
   where
     monoExpr' (Variable var       ) = pure $ Variable var
-    monoExpr' (Fun      fn []  nt ) = modify (first $ M.insert fn M.empty) >> return (Fun fn [] nt)
+    monoExpr' (Fun      fn []  nt ) = modify (first $ M.insert (coreFunNameToIsabelleName fn) M.empty) >> return (Fun fn [] nt)
     monoExpr' (Fun      fn tys nt ) = do
       tys' <- mapM monoType tys
-      modify (first $ M.insertWith (\_ m -> insertWith (flip const) tys' (M.size m) m) fn (M.singleton tys' 0))  -- add one more instance to the env
-      idx <- M.lookup tys' . fromJust . M.lookup fn . fst <$> get
-      return $ Fun (monoName fn idx) [] nt  -- used to be tys'
+      modify (first $ M.insertWith (\_ m -> insertWith (flip const) tys' (M.size m) m) (coreFunNameToIsabelleName fn) (M.singleton tys' 0))  -- add one more instance to the env
+      idx <- M.lookup tys' . fromJust . M.lookup (coreFunNameToIsabelleName fn) . fst <$> get
+      return $ Fun (unsafeIsabelleNameToCoreFunName $ monoName fn idx) [] nt  -- used to be tys'
     monoExpr' (Op      opr es     ) = Op opr <$> mapM monoExpr es
     monoExpr' (App     e1 e2      ) = App <$> monoExpr e1 <*> monoExpr e2
     monoExpr' (Con     tag e t    ) = Con tag <$> monoExpr e <*> monoType t

--- a/cogent/src/Cogent/PrettyPrint.hs
+++ b/cogent/src/Cogent/PrettyPrint.hs
@@ -585,7 +585,7 @@ instance Pretty RepExpr where
 
 
 instance Pretty Metadata where
-  pretty (Constant {varName})                = err "the binding" <+> funname varName <$> err "is a global constant"
+  pretty (Constant {constName})              = err "the binding" <+> funname constName <$> err "is a global constant"
   pretty (Reused {varName, boundAt, usedAt}) = err "the variable" <+> varname varName
                                                <+> err "bound at" <+> pretty boundAt <> err ""
                                                <$> err "was already used at"

--- a/cogent/src/Cogent/Reorganizer.hs
+++ b/cogent/src/Cogent/Reorganizer.hs
@@ -16,7 +16,7 @@
 
 module Cogent.Reorganizer where
 
-import Cogent.Common.Syntax
+import qualified Cogent.Common.Syntax as Syn
 import Cogent.Compiler (__impossible)
 import Cogent.Surface
 import Cogent.Util
@@ -35,9 +35,9 @@ data ReorganizeError = CyclicDependency
                      | DuplicateValueDefinition
                      | DuplicateRepDefinition
 
-data SourceObject = TypeName TypeName
-                  | ValName  VarName
-                  | RepName RepName
+data SourceObject = TypeName  Syn.TypeName
+                  | ValName   Syn.VarName
+                  | RepName   Syn.RepName
                   | DocBlock' String
                   deriving (Eq, Ord)
 

--- a/cogent/src/Cogent/Simplify.hs
+++ b/cogent/src/Cogent/Simplify.hs
@@ -120,7 +120,7 @@ markOcc sv (TE tau (Variable (v, n))) = do
   modify $ second $ modifyAt v (OnceSafe <>)
   return . TE tau $ Variable (v, (n, OnceSafe))
 markOcc sv (TE tau (Fun fn ts note)) = do
-  modify (first $ M.adjust (second $ (OnceSafe <>)) fn)
+  modify (first $ M.adjust (second $ (OnceSafe <>)) (coreFunNameToIsabelleName fn))
   return . TE tau $ Fun fn ts note
 markOcc sv (TE tau (Op opr es)) = TE tau . Op opr <$> mapM (markOcc sv) es
 markOcc sv (TE tau (App f e)) = TE tau <$> (App <$> markOcc sv f <*> markOcc sv e)
@@ -305,14 +305,14 @@ simplExpr sv subst ins (TE tau (Op opr es)) cont = TE tau . Op opr <$> mapM (fli
 simplExpr sv subst ins (TE tau (App (TE tau1 (Fun fn tys note)) e2)) cont
   | note `elem` [InlineMe, InlinePlease], ExI (Flip tys') <- V.fromList tys = do
   e2' <- simplExpr sv subst ins e2 cont
-  def <- fst . fromJust . M.lookup fn <$> use funcEnv
+  def <- fst . fromJust . M.lookup (coreFunNameToIsabelleName fn) <$> use funcEnv
   case def of
     FunDef attr fn ts ti to fb -> do
       env <- get
       fb' <- return $ evalSimp (SimpEnv (env^.funcEnv) (fmap snd ts) (env^.varCount)) $
                simplExpr s1 (emptySubst s1) (emptyInScopeSet s1) (evalOcc (env^.funcEnv, emptyOccVec s1) $ markOcc s1 fb) Stop
       betaR fb' s0 sv e2' (unsafeCoerce tys')  -- FIXME
-    AbsDecl attr fn ts ti to    -> return $ TE tau $ App (TE tau1 (Fun fn tys note)) e2'
+    AbsDecl attr fn ts ti to    -> return $ TE tau $ App (TE tau1 (Fun (unsafeIsabelleNameToCoreFunName fn) tys note)) e2'
     _ -> __impossible "simplExpr"
 simplExpr sv subst ins (TE tau (App e1 e2))  cont = TE tau <$> (App <$> simplExpr sv subst ins e1 cont <*> simplExpr sv subst ins e2 cont)
 simplExpr sv subst ins (TE tau (Con cn e t)) cont = TE tau <$> (Con cn <$> simplExpr sv subst ins e cont <*> pure t)

--- a/cogent/src/Cogent/Surface.hs
+++ b/cogent/src/Cogent/Surface.hs
@@ -153,9 +153,9 @@ data TopLevel t p e = Include    String
                     | DocBlock   String
                     | AbsTypeDec TypeName [TyVarName] [t]
                     | TypeDec    TypeName [TyVarName] t
-                    | AbsDec VarName (Polytype t)
-                    | FunDef VarName (Polytype t) [Alt p e]
-                    | ConstDef VarName t e
+                    | AbsDec     FunName (Polytype t)
+                    | FunDef     FunName (Polytype t) [Alt p e]
+                    | ConstDef   ConstName t e
                     | RepDef RepDecl
                     deriving (Eq, Show, Functor, Foldable, Traversable)
 

--- a/cogent/src/Cogent/TypeCheck/Base.hs
+++ b/cogent/src/Cogent/TypeCheck/Base.hs
@@ -143,9 +143,9 @@ data Metadata = Reused { varName :: VarName, boundAt :: SourcePos, usedAt :: Seq
               | UsedInArrayIndexing
 #endif
               | UsedInLetBang
-              | TypeParam { functionName :: VarName, typeVarName :: VarName }
+              | TypeParam { functionName :: FunName, typeVarName :: TyVarName }
               | ImplicitlyTaken
-              | Constant { varName :: VarName }
+              | Constant { constName :: ConstName }
               deriving (Eq, Show, Ord)
 
 data Constraint = (:<) (TypeFragment TCType) (TypeFragment TCType)


### PR DESCRIPTION
Individuate core function names from String. This will eventually lead into type level checking of generated Isabelle names, to make sure they don't start or end with `_`.