### PR TITLE
flatten case expressions in shallow embedding

### DIFF
--- a/cogent/cogent.cabal
+++ b/cogent/cogent.cabal
@@ -76,6 +76,7 @@ library
               , Cogent.Inference
               , Cogent.Isabelle.ACInstall
               , Cogent.Isabelle.AllRefine
+              , Cogent.Isabelle.Compound
               , Cogent.Isabelle.CorresProof
               , Cogent.Isabelle.CorresSetup
               , Cogent.Isabelle.Deep

--- a/cogent/isa/shallow/Shallow_Normalisation_Tac.thy
+++ b/cogent/isa/shallow/Shallow_Normalisation_Tac.thy
@@ -82,7 +82,7 @@ ML {*
 fun inline_case_continuation_conv ctxt thm =
   Conv.bottom_conv (fn _ => fn ct => case Thm.term_of ct of
             Const ("HOL.Let", _) $ _ $ Abs (v, _, _) =>
-              if String.isPrefix "v\<^sub>G" v then Conv.rewr_conv @{thm Let_def} ct else Conv.all_conv ct
+              if String.isPrefix "ccase\<^sub>G" v then Conv.rewr_conv @{thm Let_def} ct else Conv.all_conv ct
           | _ => Conv.all_conv ct)
     ctxt
   |> (fn conv => Conv.fconv_rule conv thm)

--- a/cogent/src/Cogent/Isabelle/Compound.hs
+++ b/cogent/src/Cogent/Isabelle/Compound.hs
@@ -1,0 +1,158 @@
+--
+-- Copyright 2019, Data61
+--
+-- This software may be distributed and modified according to the terms of
+-- the GNU General Public License version 2. Note that NO WARRANTY is provided.
+-- See "LICENSE_GPLv2.txt" for details.
+--
+-- @TAG(DATA61_GPL)
+--
+
+{-
+  Compound: taking apart compound expressions, and putting them back together
+-}
+
+{-# OPTIONS_GHC -Werror -Wall #-}
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE TupleSections #-}
+
+module Cogent.Isabelle.Compound
+    ( takeFlatCase
+    , expDiscardVar
+    , discardVar
+    )
+  where
+
+import Cogent.Common.Syntax
+import Cogent.Core
+
+import Control.Applicative
+import qualified Data.Map as M
+import Data.Maybe
+import Prelude as P
+import Data.Nat
+import Data.Vec
+
+-- | Try to flatten a nested case into a map of alternatives
+--
+-- A Core program like:
+--
+-- > Case scrut tag1 (n1, when_tag1)
+-- >  (Case (Var 0) tag2 (n2, when_tag2)
+-- >    (Let n3 (Esac (Var 0)) when_tag3)
+--
+-- becomes something like
+--
+-- > Just (scrut, fromList [(tag1, (n1, when_tag1)), (tag2, (n2, when_tag2)), (tag3, (n3, when_tag3))])
+--
+takeFlatCase :: TypedExpr t v VarName
+             -> Maybe ( TypedExpr t v VarName
+                      , M.Map TagName (VarName, TypedExpr t ('Suc v) VarName))
+takeFlatCase (TE _ e) = case e of
+ -- Take top-level case separately as we need the scrutinee here,
+ -- while the nested levels must have a scrutinee of (Var 0).
+ (Case escrut tag (_,n1,e1) (_,n2,e2))
+  | TSum talts <- exprType escrut
+  -> do let m0 = M.singleton tag (n1,e1)
+        -- Descend into failure case to match remaining alternatives 
+        malts <- goAlts n2 e2 m0
+        -- Only succeed if we have alternatives for all variant constructors
+        case M.size malts == P.length talts of
+         True  -> Just (escrut,malts)
+         False -> Nothing
+
+ _ -> Nothing
+
+ where
+  goAlts :: forall t u. VarName -> TypedExpr t u VarName -> (M.Map TagName (VarName, TypedExpr t u VarName)) -> Maybe (M.Map TagName (VarName, TypedExpr t u VarName))
+  -- Match a nested Case on the same scrutinee
+  goAlts nscrut (TE _ (Case (TE _ (Variable (FZero, nscrut'))) tag (_, na1,ea1) (_, na2, ea2))) m
+   | nscrut == nscrut'
+   = do -- The nested case structure binds a lot of variables that all refer to the scrutinee,
+        -- because the failure continuation of each nested case has a binding.
+        -- To flatten the case, we need all alternatives to have the same environment.
+        -- After doing a nested case, the scrutinee variable usually isn't referred to again:
+        -- we need to make sure it isn't referred to, and remove it from the context.
+        ea1' <- expDiscardVar (FSuc FZero) ea1
+        ea2' <- expDiscardVar (FSuc FZero) ea2
+        goAlts na2 ea2' (M.insert tag (na1,ea1') m)
+
+  -- Match an Esac
+  goAlts nscrut (TE _ (Let nalt (TE _ (Esac (TE tscrut (Variable (FZero, nscrut'))))) erest)) m
+   | nscrut == nscrut'
+   , TSum alts <- tscrut
+   , [tag]     <- map fst $ filter (\(_,(_,b)) -> not b) alts
+   = do erest' <- expDiscardVar (FSuc FZero) erest
+        Just $ M.insert tag (nalt,erest') m
+
+  goAlts _ _ _
+   = Nothing
+
+-- | Try to discard a variable from an expression context
+-- If the variable is not mentioned, return an equivalent expression with a smaller context.
+-- If the variable is mentioned, return Nothing.
+--
+-- This function is pretty trivial, but it's a bit tedious because of the de Bruijn indices.
+expDiscardVar :: Fin ('Suc v) -> TypedExpr t ('Suc v) VarName -> Maybe (TypedExpr t v VarName)
+expDiscardVar rm0 (TE t0 e0) = TE t0 <$> case e0 of
+  Variable (v, a)     -> Variable <$> ((,) <$> discardVar rm0 v <*> pure a)
+  Fun a b c           -> pure $ Fun a b c
+  Op o ls             -> Op o <$> mapM go ls
+  App e1 e2           -> App <$> go e1 <*> go e2
+  Con tag e ty        -> Con <$> pure tag <*> go e <*> pure ty
+  Unit                -> pure Unit
+  ILit i j            -> pure $ ILit i j
+  SLit s              -> pure $ SLit s
+  Let a e1 e2         -> Let a <$> go e1 <*> goSuc e2
+  LetBang fs a e1 e2  -> LetBang <$> mapM (mfirst $ discardVar rm0) fs <*> pure a <*> go e1 <*> goSuc e2
+  Tuple e1 e2         -> Tuple <$> go e1 <*> go e2
+  Struct fes          -> Struct <$> mapM (msecond go) fes
+  If ep et ef         -> If <$> go ep <*> go et <*> go ef
+  Case es tag (l1,n1,e1) (l2,n2,e2)
+                      -> Case <$> go es <*> pure tag
+                      <*> ((l1,n1,) <$> goSuc e1)
+                      <*> ((l2,n2,) <$> goSuc e2)
+  Esac es             -> Esac <$> go es
+  Split (n,n') es et  -> Split (n,n') <$> go es <*> goSuc2 et
+  Member e1 f         -> Member <$> go e1 <*> pure f
+  Take (n,n') es f et -> Take (n,n') <$> go es <*> pure f <*> goSuc2 et
+  Put e1 f e2         -> Put <$> go e1 <*> pure f <*> go e2
+  Promote t e1        -> Promote t <$> go e1
+  Cast t e1           -> Cast t <$> go e1
+#ifdef BUILTIN_ARRAYS
+  ALit es             -> ALit <$> mapM go es
+  ArrayIndex e1 i     -> ArrayIndex <$> go e1 <*> pure i
+  Pop (n,n') e1 e2    -> Pop (n,n') <$> go e1 <*> goSuc2 e2
+  Singleton e1        -> Singleton <$> go e1
+#endif
+ where
+  go     = expDiscardVar rm0
+  goSuc  = expDiscardVar (FSuc rm0)
+  goSuc2 = expDiscardVar (FSuc $ FSuc rm0)
+  mfirst  f (a,b) = (,) <$> f    a <*> pure b
+  msecond f (a,b) = (,) <$> pure a <*> f    b
+
+
+-- | Check if two variables are different: if so, remove first variable from second's context
+--
+-- > discard i j
+-- > | i == j = Nothing
+-- > | i <  j = Just (j - 1)
+-- > | i >  j = Just j
+--
+discardVar :: forall v. Fin ('Suc v) -> Fin ('Suc v) -> Maybe (Fin v)
+discardVar FZero    FZero    = Nothing
+discardVar (FSuc r) FZero    = case r of
+  -- Need to match on r again to prove that type 'v' is actually a Suc...
+  FZero  -> Just FZero
+  FSuc _ -> Just FZero
+discardVar FZero    (FSuc v) = Just v
+discardVar (FSuc r) (FSuc v) = case (r,v) of
+  (FZero, FZero)  -> FSuc <$> discardVar r v
+  (FSuc _,FZero)  -> FSuc <$> discardVar r v
+  (FZero, FSuc _) -> FSuc <$> discardVar r v
+  (FSuc _,FSuc _) -> FSuc <$> discardVar r v
+

--- a/cogent/src/Cogent/Isabelle/Shallow.hs
+++ b/cogent/src/Cogent/Isabelle/Shallow.hs
@@ -232,7 +232,7 @@ shallowExpr (TE t (Case e tag (_,n1,e1) (_,n2,e2))) = do
   vn <- varNameGen <<%= (+1)
   vn2 <- varNameGen <<%= (+1)
   let vgn = "v" ++ (subSymStr $ "G" ++ show vn)
-      vgn2 = "v" ++ (subSymStr $ "G" ++ show vn2)  -- This is the continuation @e2@
+      vgn2 = "ccase" ++ (subSymStr $ "G" ++ show vn2)  -- This is the continuation @e2@
       es = flip map alts $ \(tag',(t',b')) ->
              if | tag == tag' -> e1'
                 | otherwise -> 

--- a/cogent/tests/pass_ex-variants.cogent
+++ b/cogent/tests/pass_ex-variants.cogent
@@ -8,17 +8,17 @@
 -- @TAG(NICTA_GPL)
 --
 
-type T1 = < Good U8 Bool           | Bad           >
-type T2 = < SuperGood T1 U32 U32   | KindOfBad U32 | Restart >
-type T3 = < Pretty (S U8 Bool) U32 | Ugly          >
+type X1 = < Good U8 Bool           | Bad           >
+type X2 = < SuperGood X1 U32 U32   | KindOfBad U32 | Restart >
+type X3 = < Pretty (S U8 Bool) U32 | Ugly          >
 
 type S a b
 
-foo : T1 -> U32
+foo : X1 -> U32
 foo | Good a b -> if b then upcast a else 1
     | Bad      -> 255
 
-bar : T2 -> T1
+bar : X2 -> X1
 bar t2 = t2
   | SuperGood t1 n1 n2 -> t1
   | KindOfBad err -> Bad


### PR DESCRIPTION
We can generate nicer cases. This should make the shallow embeddings a lot smaller and nicer, and fix some of the problems with code explosion in the continuation for cases.

Extended SCorres rule looks something like this:

```

(*
datatype ('a, 'b, 'c) X2 =
  KindOfBad "'a"|
  Restart "'b"|
  SuperGood "'c"
*)
lemma scorres_supercase_X2 :
  "scorres x x' γ ξ ⟹ 
  (⋀v v'. valRel ξ v v' ⟹ scorres ((if t1 = ''KindOfBad'' then skindofbad else if t1 = ''Restart'' then srestart else ssupergood) (shallow_tac__var v)) d1 (v'#γ) ξ) ⟹ 
  (⋀v v'. valRel ξ v v' ⟹ scorres ((if t2 = ''KindOfBad'' then skindofbad else if t2 = ''Restart'' then srestart else ssupergood) (shallow_tac__var v)) d2 (v' # VSum t2 v' # γ) ξ) ⟹ 
  (⋀v v'. valRel ξ v v' ⟹ scorres ((if t3 = ''KindOfBad'' then skindofbad else if t3 = ''Restart'' then srestart else ssupergood) (shallow_tac__var v)) d3 (v' # VSum t3 v' # VSum t3 v' # γ) ξ) ⟹ 
  scorres (case_X2 skindofbad srestart ssupergood x) (Case x' t1 d1 (Case (Var 0) t2 d2 (Let (Esac (Var 0) t3) d3))) γ ξ"
  apply (clarsimp simp: scorres_def shallow_tac__var_def valRel_X2)
  apply (erule v_sem_caseE)
   apply (cases x)
     apply fastforce
    apply fastforce
   apply fastforce

  apply (erule v_sem_caseE)
   apply (cases x; clarsimp)
     apply fastforce
    apply fastforce
   apply fastforce

  apply (erule v_sem_letE)
  apply (erule v_sem_esacE)
  apply (erule v_sem_varE)
  apply (cases x)
    apply fastforce
   apply fastforce
  apply fastforce
  done

```