### PR TITLE
compiler: Fix isabelle renaming to be consistent

### DIFF
--- a/cogent/cogent.cabal
+++ b/cogent/cogent.cabal
@@ -89,6 +89,7 @@ library
               , Cogent.Isabelle.Shallow
               , Cogent.Isabelle.ShallowTable
               , Cogent.Isabelle.TypeProofs
+              , Cogent.Isabelle.IsabelleName
               , Cogent.Mono
               , Cogent.Normal
               , Cogent.Parser

--- a/cogent/src/Cogent/Common/Syntax.hs
+++ b/cogent/src/Cogent/Common/Syntax.hs
@@ -11,9 +11,7 @@ import Data.Data hiding (Prefix)
 import Data.Monoid
 #endif
 import Data.Word
-import Data.Char (isDigit)
 import Text.PrettyPrint.ANSI.Leijen
-import Isabelle.Parser (reservedWords)
 
 type RepName     = String
 type FieldName   = String
@@ -26,35 +24,6 @@ type TypeName    = String
 
 newtype CoreFunName = CoreFunName { unCoreFunName :: String }
   deriving (Eq, Show, Ord)
-
-newtype IsabelleName = IsabelleName { unIsabelleName :: String }
-  deriving (Eq, Show, Ord)
-
-isReserved :: IsabelleName -> Bool
-isReserved (IsabelleName n) = n `elem` reservedWords
-
-isInvalid :: IsabelleName -> Bool
-isInvalid (IsabelleName n) =
-  isDigit (head n) && head n == '_' 
-
-unsafeMakeIsabelleName :: String -> IsabelleName
-unsafeMakeIsabelleName = mkIsabelleName . CoreFunName
-
-{-
- - We change the name of the embedding as follows so:
- - 1) We don't use a reserved word for a function name (e.g. 'function' or 'open')
- - 2) We don't generate invalid names (like _free, free_, 1free, etc.)
- - 3) We don't take a name in the Isabelle standard proof library (e.g. 'map')
--}
-mkIsabelleName :: CoreFunName -> IsabelleName
-mkIsabelleName (CoreFunName s) = IsabelleName ("cogent_" ++ s ++ "'")
-
-editIsabelleName :: IsabelleName -> (String -> String) -> Maybe IsabelleName
-editIsabelleName (IsabelleName n) f  = 
-  if (not (isReserved (IsabelleName $ f n) || isInvalid (IsabelleName $ f n))) then
-    Just $ IsabelleName (f n)
-  else 
-    Nothing
 
 funNameToCoreFunName :: FunName -> CoreFunName
 funNameToCoreFunName = CoreFunName

--- a/cogent/src/Cogent/Isabelle/CorresProof.hs
+++ b/cogent/src/Cogent/Isabelle/CorresProof.hs
@@ -18,6 +18,7 @@ import Data.List (intercalate)
 -- import Isabelle.ExprTH
 import Isabelle.InnerAST as I
 import Isabelle.OuterAST as O
+import Cogent.Isabelle.IsabelleName
 import System.FilePath ((</>))
 import qualified Text.PrettyPrint.ANSI.Leijen as L
 
@@ -218,7 +219,8 @@ cogentMainTree thy ent =
   ] ++ (case ent of
          Nothing ->   [ "val entry_func_names = Cogent_functions (* all functions *)" ]
          Just tlfs -> [ "val entry_func_names = [" ] ++
-                      lines (intercalate ",\n" (map (\tlf -> "      \"" ++ tlf ++ "\"") (map unCoreFunName tlfs))) ++
+                      lines (intercalate ",\n" (map (\tlf -> "      \"" ++ tlf ++ "\"") 
+                      (map (unIsabelleName . mkIsabelleName . unCoreFunName) tlfs))) ++
                       [ "]" ]
        ) ++
   [ "val entry_funcs = Symtab.dest Cogent_main_tree"

--- a/cogent/src/Cogent/Isabelle/Deep.hs
+++ b/cogent/src/Cogent/Isabelle/Deep.hs
@@ -28,6 +28,7 @@ import Data.Vec (cvtToList, Fin, finInt)
 import Isabelle.ExprTH
 import Isabelle.InnerAST as I
 import Isabelle.OuterAST as O
+import Cogent.Isabelle.IsabelleName
 
 #if __GLASGOW_HASKELL__ >= 709
 import Prelude hiding ((<$>))
@@ -131,8 +132,8 @@ deepPrimOp CS.Complement t = mkApp (mkId "Complement") [deepNumType t]
 deepExpr :: (Pretty a) => NameMod -> TypeAbbrevs -> [Definition TypedExpr a] -> TypedExpr t v a -> Term
 deepExpr mod ta defs (TE _ (Variable v)) = mkApp (mkId "Var") [deepIndex (fst v)]
 deepExpr mod ta defs (TE _ (Fun fn ts _))
-  | concreteFun fn = mkApp (mkId "Fun")  [mkId (mod (unIsabelleName $ mkIsabelleName fn)), mkList (map (deepType mod ta) ts)]
-  | otherwise      = mkApp (mkId "AFun") [mkString (unIsabelleName $ mkIsabelleName fn), mkList (map (deepType mod ta) ts)]
+  | concreteFun fn = mkApp (mkId "Fun")  [mkId (mod (unIsabelleName $ mkIsabelleName $ unCoreFunName fn)), mkList (map (deepType mod ta) ts)]
+  | otherwise      = mkApp (mkId "AFun") [mkString (unIsabelleName $ mkIsabelleName $ unCoreFunName fn), mkList (map (deepType mod ta) ts)]
   where
     concreteFun :: CoreFunName -> Bool
     concreteFun f = any (\def -> isFuncId f def && case def of FunDef{} -> True; _ -> False) defs
@@ -204,19 +205,19 @@ deepDefinition :: NameMod -> TypeAbbrevs -> [Definition TypedExpr a] -> Definiti
                     [TheoryDecl I.Type I.Term] -> [TheoryDecl I.Type I.Term]
 deepDefinition mod ta defs (FunDef _ fn ks ti to e) decls =
   let ty = deepPolyType mod ta $ FT (fmap snd ks) ti to
-      tn = case editIsabelleName (mkIsabelleName $ unsafeNameToCoreFunName fn) (++ "_type")  of
+      tn = case editIsabelleName (mkIsabelleName fn) (++ "_type")  of
             Just n  -> unIsabelleName n
             Nothing -> error "Error - unable to generate name for isabelle function " ++ fn
       tysig = [isaType| Cogent.kind list \<times> Cogent.type \<times> Cogent.type |]
       tydecl = [isaDecl| definition $tn :: "$tysig" where "$(mkId tn) \<equiv> $ty" |]
       e' = deepExpr mod ta defs e
       fntysig = AntiType "string Cogent.expr"
-      fn' = unIsabelleName (mkIsabelleName $ unsafeNameToCoreFunName fn)
+      fn' = unIsabelleName (mkIsabelleName fn)
       decl = [isaDecl| definition $fn' :: "$fntysig" where "$(mkId fn') \<equiv> $e'" |]
      in tydecl:decl:decls
 deepDefinition mod ta _ (AbsDecl _ fn ks ti to) decls =
     let ty = deepPolyType mod ta $ FT (fmap snd ks) ti to
-        tn = case editIsabelleName (mkIsabelleName $ unsafeNameToCoreFunName fn) (++ "_type") of 
+        tn = case editIsabelleName (mkIsabelleName fn) (++ "_type") of 
             Just n  -> unIsabelleName n
             Nothing -> error "Error - unable to generate name for isabelle function " ++ fn
         tysig = [isaType| Cogent.kind list \<times> Cogent.type \<times> Cogent.type |]
@@ -228,7 +229,7 @@ deepDefinitions :: NameMod -> TypeAbbrevs -> [Definition TypedExpr a] -> [Theory
 deepDefinitions mod ta defs = foldr (deepDefinition mod ta defs) [] defs ++
                               [TheoryString $
                                "ML {*\n" ++
-                               "val Cogent_functions = [" ++ showStrings (map mod $ cogentFuns defs) ++ "]\n" ++
+                               "val Cogent_functions = [" ++ showStrings (map (unIsabelleName . mkIsabelleName) $ cogentFuns defs) ++ "]\n" ++
                                "val Cogent_abstract_functions = [" ++ showStrings (map mod $ absFuns defs) ++ "]\n" ++
                                "*}"
                               ]

--- a/cogent/src/Cogent/Isabelle/IsabelleName.hs
+++ b/cogent/src/Cogent/Isabelle/IsabelleName.hs
@@ -1,0 +1,73 @@
+--
+-- Copyright 2019, NICTA
+--
+-- This software may be distributed and modified according to the terms of
+-- the GNU General Public License version 2. Note that NO WARRANTY is provided.
+-- See "LICENSE_GPLv2.txt" for details.
+--
+-- @TAG(NICTA_GPL)
+--
+
+module Cogent.Isabelle.IsabelleName where
+
+{-
+ - IsabelleName.hs: generate names for an Isabelle embedding that are valid and don't clash with reserved words
+ -}
+
+import Isabelle.Parser (reservedWords)
+import Isabelle.InnerAST as I
+import Cogent.Desugar as D (freshVarPrefix)
+import Cogent.Normal as N (freshVarPrefix)
+
+import Data.List (stripPrefix, isPrefixOf, isSuffixOf)
+import Data.Char (isDigit)
+
+
+newtype IsabelleName = IsabelleName { unIsabelleName :: String }
+  deriving (Eq, Show, Ord)
+
+{-
+ - We change the name of the embedding as follows so:
+ - 1) We don't use a reserved word for a function name (e.g. 'function' or 'open')
+ - 2) We don't generate invalid names (like _free, free_, 1free, etc.)
+ - 3) We don't take a name in the Isabelle standard proof library (e.g. 'map')
+-}
+safeName :: IsabelleName -> IsabelleName
+safeName (IsabelleName nm) = IsabelleName $
+  case isReserved nm of
+    True -> nm ++ "_r"
+    _ -> case stripPrefix D.freshVarPrefix nm of
+      Just nb -> "ds" ++ subSymStr nb
+      Nothing -> case stripPrefix N.freshVarPrefix nm of
+        Just nb -> "an" ++ subSymStr nb
+        -- Add debug note
+        Nothing -> case "_" `isPrefixOf` nm of
+          True  -> dropWhile (== '_') nm ++ subSymStr "d"
+          False -> case "_" `isSuffixOf` nm of
+            True  -> nm ++ subSymStr "x"
+            False -> nm
+
+isReserved :: String -> Bool
+isReserved n = n `elem` reservedWords
+
+isInvalid :: String -> Bool
+isInvalid n =
+  isDigit (head n) || "_" `isPrefixOf` n || "_" `isSuffixOf` n
+
+badName :: String -> Bool
+badName s = isReserved s || isInvalid s
+
+{- 
+ - Generates a name that can be used in the isabelle embedding.
+ - If the name is invalid, it is mapped to a valid name.
+ - This name is suitable both for Isabelle ML and Isabelle (i.e. ascii only)
+ -}
+mkIsabelleName :: String -> IsabelleName
+mkIsabelleName = safeName . IsabelleName
+
+editIsabelleName :: IsabelleName -> (String -> String) -> Maybe IsabelleName
+editIsabelleName (IsabelleName n) f  = 
+  if badName n then
+    Nothing
+  else 
+    Just $ IsabelleName (f n)

--- a/cogent/src/Cogent/Isabelle/IsabelleName.hs
+++ b/cogent/src/Cogent/Isabelle/IsabelleName.hs
@@ -42,9 +42,9 @@ safeName (IsabelleName nm) = IsabelleName $
         Just nb -> "an" ++ subSymStr nb
         -- Add debug note
         Nothing -> case "_" `isPrefixOf` nm of
-          True  -> dropWhile (== '_') nm ++ subSymStr "d"
+          True  -> dropWhile (== '_') nm ++ "_d"
           False -> case "_" `isSuffixOf` nm of
-            True  -> nm ++ subSymStr "x"
+            True  -> nm ++ "_x"
             False -> nm
 
 isReserved :: String -> Bool

--- a/cogent/src/Cogent/Isabelle/MonoProof.hs
+++ b/cogent/src/Cogent/Isabelle/MonoProof.hs
@@ -23,6 +23,7 @@ import Cogent.Mono
 import Cogent.Util
 import Data.Nat (Nat(Zero, Suc))
 import Data.Vec
+import Cogent.Isabelle.IsabelleName
 import Isabelle.ExprTH
 import Isabelle.InnerAST as I
 import Isabelle.OuterAST as O hiding (Instance)
@@ -103,9 +104,10 @@ rename funMono = [isaDecl| definition $alist_name :: "$sig" where "$(mkId alist_
 
     subscript fn num =  fn ++ "_" ++ show num
     mkInst :: (FunName, [(Instance, Int)]) -> [(Term, Term, Term)]
-    mkInst (fn,insts) = if null insts
-                          then [([isaTerm| $(mkString fn) |], [isaTerm| Nil |], [isaTerm| $(mkString fn) |])]
-                          else map (\(tys,num) -> ([isaTerm| $(mkString fn) |], mkTyList tys, [isaTerm| $(mkString (subscript fn num)) |])) insts
+    mkInst (fn,insts) = let safeName = unIsabelleName $ mkIsabelleName fn
+      in  if null insts
+            then [([isaTerm| $(mkString safeName) |], [isaTerm| Nil |], [isaTerm| $(mkString safeName) |])]
+            else map (\(tys,num) -> ([isaTerm| $(mkString safeName) |], mkTyList tys, [isaTerm| $(mkString (subscript safeName num)) |])) insts
 
     mkTyList :: [CC.Type 'Zero] -> Term
     mkTyList = I.mkList . map (deepType id (empty, 0))

--- a/cogent/src/Cogent/Isabelle/NormalProof.hs
+++ b/cogent/src/Cogent/Isabelle/NormalProof.hs
@@ -20,6 +20,7 @@ import Cogent.Isabelle.ShallowTable (TypeStr (..))
 import Cogent.Util
 import Isabelle.InnerAST as I
 import Isabelle.OuterAST as O
+import Cogent.Isabelle.IsabelleName
 
 import Data.List
 import qualified Data.Map as M
@@ -164,7 +165,7 @@ genDesugarNormalProof sdthy snthy typeMap defs =
      caseProofs ++
      [ O.TheoryString $ unlines
        [ "ML {*"
-       , "val Cogent_functions = " ++ show fns
+       , "val Cogent_functions = " ++ (show $ map (unIsabelleName . mkIsabelleName) fns)
        , "*}"
        , ""
        , "ML {*"

--- a/cogent/src/Cogent/Isabelle/ProofGen.hs
+++ b/cogent/src/Cogent/Isabelle/ProofGen.hs
@@ -40,6 +40,7 @@ import Data.Map (Map)
 import Data.Maybe (catMaybes)
 import qualified Data.Map as M
 import Isabelle.InnerAST hiding (Type)
+import Cogent.Isabelle.IsabelleName
 import Text.PrettyPrint.ANSI.Leijen hiding ((<$>))
 
 type Xi a = [Definition TypedExpr a]
@@ -286,7 +287,8 @@ typing xi k (EE t' (Fun f ts _) env) = case findfun (unCoreFunName f) xi of
            mod <- use nameMod
            let unabbrev | M.null (fst ta) = ""
                         | otherwise = "[unfolded " ++ typeAbbrevBucketName ++ "]"
-           return [simp_add ["\\<Xi>_def", mod (unIsabelleName $ mkIsabelleName f) ++ "_type_def" ++ unabbrev]],  -- Ξ f = (K', t, u)
+           return [simp_add ["\\<Xi>_def", mod (unIsabelleName $ mkIsabelleName $ unCoreFunName f) 
+                   ++ "_type_def" ++ unabbrev]],  -- Ξ f = (K', t, u)
         allKindCorrect k ts ks,    -- list_all2 (kinding K) ts ks
         return [simp_solve,        -- t' = instantiate ts t
                 simp_solve],       -- u' = instantiate ts u
@@ -300,7 +302,7 @@ typing xi k (EE t' (Fun f ts _) env) = case findfun (unCoreFunName f) xi of
         do ta <- use tsTypeAbbrevs
            mod <- use nameMod
            let unabbrev | M.null (fst ta) = "" | otherwise = " " ++ typeAbbrevBucketName
-           return [rule (fn_proof (mod (unIsabelleName $ mkIsabelleName f)) unabbrev)],  -- Ξ, K', (TT, [Some t]) ⊢T f : u
+           return [rule (fn_proof (mod (unIsabelleName $ mkIsabelleName $ unCoreFunName f)) unabbrev)],  -- Ξ, K', (TT, [Some t]) ⊢T f : u
         allKindCorrect k ts ks,  -- list_all2 (kinding K) ts K'
         return [simp_solve,      -- t' = instantiate ts t
                 simp_solve],     -- u' = instantiate ts u

--- a/cogent/src/Cogent/Isabelle/Shallow.hs
+++ b/cogent/src/Cogent/Isabelle/Shallow.hs
@@ -8,7 +8,6 @@
 -- @TAG(NICTA_GPL)
 --
 
-
 {-
  - Shallow.hs: shallow Isabelle embedding, SCorres proof and shallow-tuples proof.
  -}
@@ -38,6 +37,8 @@ import Cogent.Core as CC
 import Cogent.Desugar as D (freshVarPrefix)
 import Cogent.Isabelle.Compound (takeFlatCase)
 import Cogent.Isabelle.ShallowTable (TypeStr(..), st, getStrlType, toTypeStr)
+import Cogent.Isabelle.IsabelleName
+
 import Cogent.Normal as N (freshVarPrefix)
 import Cogent.Util (NameMod, Stage(..), Warning)
 import Data.Nat (Nat(Zero,Suc))
@@ -70,8 +71,6 @@ import Lens.Micro.Mtl
 import Debug.Trace
 
 _fixHighlighting = x where x = ()
-
-isaReservedNames = ["o", "value", "from"]
 
 type MapTypeName = M.Map TypeStr TypeName
 
@@ -157,20 +156,8 @@ shallowPrimOp CS.RShift _ = __impossible "shallowPrimOp"
 shallowPrimOp CS.Complement [e] = mkApp (mkId "NOT") [e]
 shallowPrimOp CS.Complement _ = __impossible "shallowPrimOp"
 
--- | Strip names and format them for Isabelle
 snm :: NameMod
-snm nm = case nm `elem` isaReservedNames of
-  True -> nm ++ I.subSym ++ "r"
-  _ -> case stripPrefix D.freshVarPrefix nm of
-    Just nb -> "ds" ++ subSymStr nb
-    Nothing -> case stripPrefix N.freshVarPrefix nm of
-      Just nb -> "an" ++ subSymStr nb
-      -- Add debug note
-      Nothing -> case "_" `isPrefixOf` nm of
-        True  -> dropWhile (== '_') nm ++ subSymStr "d"
-        False -> case "_" `isSuffixOf` nm of
-          True  -> nm ++ subSymStr "x"
-          False -> nm
+snm = unIsabelleName . mkIsabelleName
 
 list2 a b = [a,b]
 
@@ -194,7 +181,7 @@ findTypeSyn t = findType t >>= \(TCon nm _ _) -> pure nm
 
 shallowExpr :: TypedExpr t v VarName -> SG Term
 shallowExpr (TE _ (Variable (_,v))) = pure $ mkId (snm v)
-shallowExpr (TE _ (Fun fn ts _)) = pure $ mkId $ snm $ (unIsabelleName $ mkIsabelleName fn)  -- only prints the fun name
+shallowExpr (TE _ (Fun fn ts _)) = pure $ mkId $ snm $ unCoreFunName fn  -- only prints the fun name
 shallowExpr (TE _ (Op opr es)) = shallowPrimOp <$> pure opr <*> (mapM shallowExpr es)
 shallowExpr (TE _ (App f arg)) = mkApp <$> shallowExpr f <*> (mapM shallowExpr [arg])
 shallowExpr (TE t (Con cn e _))  = do

--- a/cogent/src/Cogent/Isabelle/TypeProofs.hs
+++ b/cogent/src/Cogent/Isabelle/TypeProofs.hs
@@ -50,6 +50,7 @@ import Isabelle.ExprTH
 import qualified Isabelle.InnerAST as I
 import Isabelle.InnerAST hiding (Type)
 import Isabelle.OuterAST as O
+import Cogent.Isabelle.IsabelleName
 import Numeric
 #if __GLASGOW_HASKELL__ >= 709
 import Prelude hiding ((<$>))
@@ -127,7 +128,7 @@ formatSubproof ta name (schematic, prop) steps =
 
 formatMLTreeGen :: String -> [TheoryDecl I.Type I.Term]
 formatMLTreeGen name =
-  let safeName = unIsabelleName $ unsafeMakeIsabelleName name
+  let safeName = unIsabelleName $ mkIsabelleName name
   in [ TheoryString ( "ML_quiet {*\nval " ++ safeName ++ "_ttyping_details_future"
     ++ " = get_all_typing_details_future @{context} \"" ++ safeName ++ "\"\n"
     ++ "   " ++ safeName ++ "_typecorrect_script"
@@ -136,7 +137,7 @@ formatMLTreeGen name =
 
 formatMLTreeFinalise :: String -> [TheoryDecl I.Type I.Term]
 formatMLTreeFinalise name =
-  let safeName = unIsabelleName $ unsafeMakeIsabelleName name
+  let safeName = unIsabelleName $ mkIsabelleName name
   in [ TheoryString ( "ML_quiet {*\nval (_, "
     ++ safeName ++ "_typing_tree, " ++ safeName ++ "_typing_bucket)\n"
     ++ "= Future.join " ++ safeName ++ "_ttyping_details_future\n*}\n"
@@ -144,7 +145,7 @@ formatMLTreeFinalise name =
 
 formatTypecorrectProof :: String -> [TheoryDecl I.Type I.Term]
 formatTypecorrectProof fn =
-  let safeFn = unIsabelleName $ unsafeMakeIsabelleName fn
+  let safeFn = unIsabelleName $ mkIsabelleName fn
   in [ LemmaDecl (Lemma False (Just $ TheoremDecl (Just (safeFn ++ "_typecorrect")) [])
           [mkId $ "\\<Xi>, prod.fst " ++ safeFn ++ "_type, (" ++ safeFn ++ "_typetree, [Some (prod.fst (prod.snd " ++ safeFn ++ "_type))]) T\\<turnstile> " ++
                   safeFn ++ " : prod.snd (prod.snd " ++ safeFn ++ "_type)"]
@@ -166,7 +167,7 @@ flattenHintTree (Leaf h) = [Val h]
 proveSorry :: (Pretty a) => Definition TypedExpr a -> State TypingSubproofs [TheoryDecl I.Type I.Term]
 proveSorry (FunDef _ fn k ti to e) = do
   mod <- use nameMod
-  let safeFn = unIsabelleName $ unsafeMakeIsabelleName fn
+  let safeFn = unIsabelleName $ mkIsabelleName fn
   let prf = [ LemmaDecl (Lemma False (Just $ TheoremDecl (Just (mod safeFn ++ "_typecorrect")) [])
           [mkId $ "\\<Xi>, prod.fst " ++ safeFn ++ "_type, (" ++ safeFn ++ "_typetree, [Some (prod.fst (prod.snd " ++ safeFn ++ "_type))]) T\\<turnstile> " ++
                   safeFn ++ " : prod.snd (prod.snd " ++ safeFn ++ "_type)"]
@@ -181,7 +182,7 @@ prove decls (FunDef _ fn k ti to e) = do
   let eexpr = pushDown (Cons (Just ti) Nil) (splitEnv (Cons (Just ti) Nil) e)
   proofSteps' <- proofSteps decls (fmap snd k) ti eexpr
   ta <- use tsTypeAbbrevs
-  let typecorrect_script = formatMLProof (mod (unIsabelleName $ unsafeMakeIsabelleName fn) ++ "_typecorrect_script") "hints treestep" (map show $ flattenHintTree proofSteps')
+  let typecorrect_script = formatMLProof (mod (unIsabelleName $ mkIsabelleName fn) ++ "_typecorrect_script") "hints treestep" (map show $ flattenHintTree proofSteps')
   let fn_typecorrect_proof = typecorrect_script ++ (if __cogent_fml_typing_tree then formatMLTreeGen (mod fn) else []) ++ formatTypecorrectProof (mod fn)
   return (fn_typecorrect_proof, if __cogent_fml_typing_tree then formatMLTreeFinalise (mod fn) else [])
 prove _ _ = return ([], [])
@@ -214,7 +215,7 @@ badHackSplitOnSorryBefore decls =
   should_sorry _ = False
 
 deepTyTreeDef :: NameMod -> TypeAbbrevs -> FunName -> TypingTree t -> TheoryDecl I.Type I.Term
-deepTyTreeDef mod ta fn e = let ttfn = mkId $ mod (unIsabelleName $ unsafeMakeIsabelleName fn) ++ "_typetree"
+deepTyTreeDef mod ta fn e = let ttfn = mkId $ mod (unIsabelleName $ mkIsabelleName fn) ++ "_typetree"
                                 tt = deepCtxTree mod ta e
                              in [isaDecl| definition "$ttfn \<equiv> $tt" |]
 
@@ -255,11 +256,11 @@ escapedFunName fn | '\'' `elem` fn = "[" ++ intercalate "," (repr fn) ++ "]"
   
 isaTypeName n = 
   unIsabelleName $ 
-    case editIsabelleName (mkIsabelleName $ funNameToCoreFunName n) (++ "_type") of
+    case editIsabelleName (mkIsabelleName n) (++ "_type") of
       Just n' -> n'
       Nothing -> error ("Error generating isabelle name for " ++ n)
 
-isaName n = unIsabelleName (mkIsabelleName $ funNameToCoreFunName n)
+isaName = unIsabelleName . mkIsabelleName
 
 funTypeCase :: NameMod -> Definition TypedExpr a -> Maybe Term
 funTypeCase mod (FunDef  _ fn _ _ _ _) =

--- a/cogent/src/Cogent/Simplify.hs
+++ b/cogent/src/Cogent/Simplify.hs
@@ -120,7 +120,7 @@ markOcc sv (TE tau (Variable (v, n))) = do
   modify $ second $ modifyAt v (OnceSafe <>)
   return . TE tau $ Variable (v, (n, OnceSafe))
 markOcc sv (TE tau (Fun fn ts note)) = do
-  modify (first $ M.adjust (second $ (OnceSafe <>)) (unIsabelleName $ mkIsabelleName fn))
+  modify (first $ M.adjust (second $ (OnceSafe <>)) (unCoreFunName fn))
   return . TE tau $ Fun fn ts note
 markOcc sv (TE tau (Op opr es)) = TE tau . Op opr <$> mapM (markOcc sv) es
 markOcc sv (TE tau (App f e)) = TE tau <$> (App <$> markOcc sv f <*> markOcc sv e)
@@ -305,7 +305,7 @@ simplExpr sv subst ins (TE tau (Op opr es)) cont = TE tau . Op opr <$> mapM (fli
 simplExpr sv subst ins (TE tau (App (TE tau1 (Fun fn tys note)) e2)) cont
   | note `elem` [InlineMe, InlinePlease], ExI (Flip tys') <- V.fromList tys = do
   e2' <- simplExpr sv subst ins e2 cont
-  def <- fst . fromJust . M.lookup (unIsabelleName $ mkIsabelleName fn) <$> use funcEnv
+  def <- fst . fromJust . M.lookup (unCoreFunName fn) <$> use funcEnv
   case def of
     FunDef attr fn ts ti to fb -> do
       env <- get


### PR DESCRIPTION
Added:
* Shallow proof to renaming
* A few extra places that weren't renamed
* No isabelle unicode symbols in ML

Fixes #300 