### PR TITLE
Bilbyfs: C version: Update to Linux kernel after 4.19.

### DIFF
--- a/impl/fs/bilby/README
+++ b/impl/fs/bilby/README
@@ -38,3 +38,16 @@ Limitations:
   does not recycle obsolete parts of the log.
 - The Cogent code can sometimes run out of stack space, hence it's recommended
   to increase the kernel stack size to run Cogent BilbyFs.
+
+# Running on a Simulated NAND disc:
+
+  modprobe nandsim first_id_byte=0xec second_id_byte=0xd3 third_id_byte=0x51 fourth_id_byte=0x95
+  modprobe ubi
+  ubiformat /dev/mtd0
+  ubiattach /dev/ubi_ctrl -m 0
+  ubimkvol /dev/ubi0 -N bilby -s 956MiB
+  ubiupdatevol /dev/ubi0_0 -t
+
+  insmod bilbyfs.ko
+  mkdir -p /mnt/disk
+  mount -t bilbyfs ubi0:bilby /mnt/disk

--- a/impl/fs/bilby/c/bilbyfs.h
+++ b/impl/fs/bilby/c/bilbyfs.h
@@ -316,7 +316,7 @@ static inline void inode_init_perm(struct inode *inode, const struct inode *dir,
 
 /* struct bilbyfs_dirent: Generic directory entry structure used for readdir
  * The structure allows to abstract away the Linux VFS filldir callback.
- * @d_ino: lnode number the directory entry is pointing to
+ * @d_ino: inode number the directory entry is pointing to
  * @d_off: offset of the directory entry in the directory
  * @d_reclen: length of the name
  * @d_type: type of inode (DT_REG, DT_DIR, DT_LNK...)
@@ -848,7 +848,7 @@ static inline u32 next_inum(struct bilbyfs_info *bi)
  * inode_current_time - round current time to time granularity.
  * @inode: inode
  */
-struct timespec inode_current_time(struct inode *inode);
+struct timespec64 inode_current_time(struct inode *inode);
 
 /* ReadDir ConteXt: This component helps to list a inline diretory by sequentially
  * reading all directory entries in a directory. 
@@ -995,18 +995,19 @@ void fsop_dir_release(struct fsop_readdir_ctx *rdx);
 /* fsop_symlink: Create a symbolic link
  * @bi: global fs info
  * @dir: directory inode in which we create symlink
- * @dentry: directory entry containing the name of the symlink
+ * @name: the name of the symlink
  * @symname: path to which the symlink points
  * @inode: inode to fill
  *
  * If the function is successful it creates a symlink inode on disk
- * and fill in information about the symlink in @inode.
+ * and fill in information about the symlink in @inode.  The new symlink's 
+ * path is put into a data object pointed to by the inode.
  * The function returns a negative error code if unsuccessful and zero
  * otherwise.
  */
 int fsop_symlink(struct bilbyfs_info *bi, struct inode *dir, const char *name, const char *symname, struct inode *inode);
 
-/* fsop_renmae: Change the name and parent for an inode
+/* fsop_rename: Change the name and parent for an inode
  * @bi: global fs info
  * @old_dir: parent directory inode of the source inode
  * @old_name: source inode to be renamed

--- a/impl/fs/bilby/c/fsop.c
+++ b/impl/fs/bilby/c/fsop.c
@@ -158,7 +158,7 @@ static int trans_commit_inodes(struct bilbyfs_info *bi, struct inode *dir,
 int fsop_link(struct bilbyfs_info *bi, struct inode *inode, struct inode *dir,
               const char *name)
 {
-        struct timespec mtime, ctime;
+        struct timespec64 mtime, ctime;
         struct obj_dentarr *dentarr;
         obj_id id;
         int sz_change;
@@ -208,7 +208,7 @@ int fsop_link(struct bilbyfs_info *bi, struct inode *inode, struct inode *dir,
  * @dir: pointer to the directory inode, is NULL iff we allocate root.
  * @mode: type + permissions of the inode
  *
- * The function returns a pointer to the inode or a negative error-code.
+ * The function returns zero or a negative error-code.
  */
 static int init_inode(struct bilbyfs_info *bi, struct inode *dir,
                       struct inode *inode, umode_t mode)
@@ -250,7 +250,7 @@ static int init_inode(struct bilbyfs_info *bi, struct inode *dir,
 int fsop_create(struct bilbyfs_info *bi, struct inode *dir, const char *name,
                 umode_t mode, int excl, struct inode *inode)
 {
-        struct timespec mtime, ctime;
+        struct timespec64 mtime, ctime;
         struct obj_dentarr *dentarr;
         obj_id id;
         int sz_change;
@@ -363,7 +363,7 @@ int fsop_rmdir(struct bilbyfs_info *bi, struct inode *dir, const char *name,
                struct inode *inode)
 {
         struct bilbyfs_inode *binode = inode_to_binode(inode);
-        struct timespec mtime, ctime;
+        struct timespec64 mtime, ctime;
         struct obj_dentarr *dentarr;
         obj_id id;
         int sz_change;
@@ -416,7 +416,7 @@ int fsop_rmdir(struct bilbyfs_info *bi, struct inode *dir, const char *name,
 int fsop_mkdir(struct bilbyfs_info *bi, struct inode *dir, const char *name,
                umode_t mode, struct inode *inode)
 {
-        struct timespec mtime, ctime;
+        struct timespec64 mtime, ctime;
         struct obj_dentarr *dentarr;
         obj_id id;
         int sz_change;
@@ -536,7 +536,7 @@ void fsop_dir_release(struct fsop_readdir_ctx *rdx)
 int fsop_symlink(struct bilbyfs_info *bi, struct inode *dir, const char *name,
                  const char *symname, struct inode *inode)
 {
-        struct timespec mtime, ctime;
+        struct timespec64 mtime, ctime;
         struct obj_dentarr *dentarr;
         obj_id id;
         struct obj_data *data;
@@ -570,7 +570,7 @@ int fsop_symlink(struct bilbyfs_info *bi, struct inode *dir, const char *name,
                         id = data_id_init(inode->i_ino, 0);
                         pack_obj_data(data, id, sz_data, symname);
                         obj_list[1] = data;
-
+			inode->i_link = NULL;
                         inode->i_size = sz_obj_data;
                         dir->i_size += sz_change;
                         /* We don't undo the next line??? */
@@ -793,11 +793,11 @@ int fsop_readpage(struct bilbyfs_info *bi, struct inode *inode, pgoff_t block, v
         pgoff_t limit = i_size_read(inode) >> BILBYFS_BLOCK_SHIFT;
         int err;
 
-        bilbyfs_assert(PAGE_CACHE_SIZE == BILBYFS_BLOCK_SIZE);
-        bilbyfs_assert(PAGE_CACHE_SHIFT == BILBYFS_BLOCK_SHIFT);
+        bilbyfs_assert(PAGE_SIZE == BILBYFS_BLOCK_SIZE);
+        bilbyfs_assert(PAGE_SHIFT == BILBYFS_BLOCK_SHIFT);
         bilbyfs_debug("[S] bilbyfs_readpage(block=%lu, limit=%lu)\n", block, limit);
         if (block > limit) {
-                memset(addr, 0, PAGE_CACHE_SIZE);
+                memset(addr, 0, PAGE_SIZE);
                 return -ENOENT;
         }
         if (block == limit && (i_size_read(inode) % BILBYFS_BLOCK_SIZE == 0))
@@ -819,7 +819,7 @@ int fsop_write_begin(struct bilbyfs_info *bi, struct inode *inode, int pos,
         if (bi->is_ro)
                 return -EROFS;
 
-        bilbyfs_assert(len <= PAGE_CACHE_SIZE);
+        bilbyfs_assert(len <= PAGE_SIZE);
         bilbyfs_debug("[S] fsop_write_begin()\n");
         err = fsop_readpage(bi, inode, pos >> BILBYFS_BLOCK_SHIFT, addr);
         if (err == -ENOENT)
@@ -831,10 +831,10 @@ int fsop_write_end(struct bilbyfs_info *bi, struct inode *inode, int pos,
                    int len, void *addr)
 {
         pgoff_t block = pos >> BILBYFS_BLOCK_SHIFT;
-        uint32_t start = pos & (PAGE_CACHE_SIZE - 1);
+        uint32_t start = pos & (PAGE_SIZE - 1);
         unsigned int end = start + len;
         unsigned int inode_size;
-        struct timespec mtime;
+        struct timespec64 mtime;
         struct obj_inode ino;
         obj_id id;
         int err;
@@ -885,7 +885,7 @@ static int fsop_truncate(struct bilbyfs_info *bi, struct inode *inode,
                          struct iattr *attr)
 {
         loff_t old_size, new_size, new_aligned_size;
-        struct timespec ctime, mtime;
+        struct timespec64 ctime, mtime;
         struct obj_inode ino;
         struct obj_del del;
         void *data;

--- a/impl/fs/bilby/c/ostore.c
+++ b/impl/fs/bilby/c/ostore.c
@@ -250,7 +250,7 @@ static inline int debug_print_objs(struct bilbyfs_info *bi, u32 lnum)
         struct bilbyfs_rbuf rbuf;
         int nbo, nbo2;
 
-        bilbyfs_debug("ostore_scan_obj() : alloc = %u\n", sizeof(*olist) * NOBJ);
+        bilbyfs_debug("ostore_scan_obj() : alloc = %lu\n", (unsigned long)(sizeof(*olist) * NOBJ));
         olist = kmalloc(sizeof(*olist) * NOBJ);
         if (!olist)
                 return -ENOMEM;


### PR DESCRIPTION
-- use 64-bit timespec
-- changed symlink implementation.
-- remove some compiler warnings
-- fix spelling errors.