### PR TITLE
Sink float fix

### DIFF
--- a/cogent/src/Cogent/TypeCheck/Solver/SinkFloat.hs
+++ b/cogent/src/Cogent/TypeCheck/Solver/SinkFloat.hs
@@ -65,15 +65,15 @@ sinkfloat = Rewrite.rewrite' $ \gs -> do {- MaybeT TcSolvM -}
   genStructSubst (R r1 s1 :< R r2 s2)
     {-
       The most tricky case.
-      For Records, Taken is the bottom of the order, Untaken is the top.
-      If taken things are in r2, then we can infer they must be in r1.
-      If untaken things are in r1, then we can infer they must be in r2.
+      For Records, untaken is the bottom of the order, taken is the top.
+      If untaken things are in r2, then we can infer they must be in r1.
+      If taken things are in r1, then we can infer they must be in r2.
     -}
-    | r1new <- Row.takenEntries r2 `M.difference` Row.entries r1
+    | r1new <- Row.untakenEntries r2 `M.difference` Row.entries r1
     , not $ M.null r1new
     , Just r1var <- Row.var r1
       = makeRowRowVarSubsts r1new r1var
-    | r2new <- Row.untakenEntries r1 `M.difference` Row.entries r2
+    | r2new <- Row.takenEntries r1 `M.difference` Row.entries r2
     , not $ M.null r2new
     , Just r2var <- Row.var r2
       = makeRowRowVarSubsts r2new r2var
@@ -86,9 +86,9 @@ sinkfloat = Rewrite.rewrite' $ \gs -> do {- MaybeT TcSolvM -}
   genStructSubst (V r1 :< V r2)
     {-
       The most tricky case.
-      For variants, Untaken is the bottom of the order, Taken is the top.
-      If untaken things are in r2, then we can infer they must be in r1.
-      If taken things are in r1, then we can infer they must be in r2.
+      For variants, taken is the bottom of the order, taken is the top.
+      If taken things are in r2, then we can infer they must be in r1.
+      If untaken things are in r1, then we can infer they must be in r2.
     -}
     | r2new <- Row.takenEntries r1 `M.difference` Row.entries r2
     , not $ M.null r2new

--- a/minigent/src/Minigent/TC/Simplify.hs
+++ b/minigent/src/Minigent/TC/Simplify.hs
@@ -42,7 +42,6 @@ simplify axs = Rewrite.pickOne $ \c -> -- trace ("About to simpliy:\n" ++ debugP
   Share  (TypeVarBang _)              -> Just []
   Drop   (RecParBang _ _)             -> Just []
   Share  (RecParBang _ _)             -> Just []
-  -- TODO: Drop/Share RecParBang?
   Share  (Variant es)                 -> guard (rowVar es == Nothing)
                                       >> Just (map Share  (Row.untakenTypes es))
   Drop   (Variant es)                 -> guard (rowVar es == Nothing)

--- a/minigent/src/Minigent/TC/SinkFloat.hs
+++ b/minigent/src/Minigent/TC/SinkFloat.hs
@@ -68,15 +68,15 @@ sinkFloat = Rewrite.rewrite' $ \cs -> do
     genStructSubst (Record _ r1 s1 :< Record _ r2 s2)
       {-
         The most tricky case.
-        Taken is the bottom of the order, Untaken is the top.
-        If taken things are in r2, then we can infer they must be in r1.
-        If untaken things are in r1, then we can infer they must be in r2.
+        Untaken is the bottom of the order, Taken is the top.
+        If untaken things are in r2, then we can infer they must be in r1.
+        If taken things are in r1, then we can infer they must be in r2.
       -}
-      | r1new <- Row.rowTakenEntries r2 `M.difference` rowEntries r1
+      | r1new <- Row.rowUntakenEntries r2 `M.difference` rowEntries r1
       , not $ M.null r1new
       , Just r1var <- rowVar r1
         = makeRowRowVarSubsts r1new r1var
-      | r2new <- Row.rowUntakenEntries r1 `M.difference` rowEntries r2
+      | r2new <- Row.rowTakenEntries r1 `M.difference` rowEntries r2
       , not $ M.null r2new
       , Just r2var <- rowVar r2
         = makeRowRowVarSubsts r2new r2var
@@ -95,9 +95,9 @@ sinkFloat = Rewrite.rewrite' $ \cs -> do
     genStructSubst (Variant r1 :< Variant r2)
       {-
         The most tricky case.
-        Untaken is the bottom of the order, Taken is the top.
-        If untaken things are in r2, then we can infer they must be in r1.
-        If taken things are in r1, then we can infer they must be in r2.
+        Taken is the bottom of the order, Untaken is the top.
+        If taken things are in r2, then we can infer they must be in r1.
+        If untaken things are in r1, then we can infer they must be in r2.
       -}
       | r1new <- Row.rowTakenEntries r2 `M.difference` rowEntries r1
       , not $ M.null r1new


### PR DESCRIPTION
* SinkFloat now propagates record subtyping the right way (taken is pushed *up*, untaken is pushed *down*)