### PR TITLE
Minigent fixes and cleanup

### DIFF
--- a/minigent/examples/6_recursive/01-basic/expected.out
+++ b/minigent/examples/6_recursive/01-basic/expected.out
@@ -1,13 +1,13 @@
-alloc : Unit -> mu t {l : <Cons {d : U8,r : rec t}#|End Unit> take};
-makeEmptyList : Unit -> mu t {l : <Cons {d : U8,r : rec t}#|End Unit>};
+alloc : Unit -> rec t {l : <Cons {d : U8,r : rec t}#|End Unit> take};
+makeEmptyList : Unit -> rec t {l : <Cons {d : U8,r : rec t}#|End Unit>};
 makeEmptyList a = let r = (alloc[] : Unit
-                                     -> mu t {l : <Cons {d : U8,r : rec t}#
-                                                  |End Unit> take}) (Unit : Unit) : mu t {l : <Cons {d : U8
-                                                                                                    ,r : rec t}#
-                                                                                              |End Unit> take}
-                  in put r : mu t {l : <Cons {d : U8,r : rec t}#
-                                       |End Unit> take}.l := End (Unit : Unit) : <Cons {d : U8
-                                                                                       ,r : rec t}#
-                                                                                 |End Unit>
-                     end : mu t {l : <Cons {d : U8,r : rec t}#|End Unit>}
-                  end : mu t {l : <Cons {d : U8,r : rec t}#|End Unit>};
+                                     -> rec t {l : <Cons {d : U8,r : rec t}#
+                                                   |End Unit> take}) (Unit : Unit) : rec t {l : <Cons {d : U8
+                                                                                                      ,r : rec t}#
+                                                                                                |End Unit> take}
+                  in put r : rec t {l : <Cons {d : U8,r : rec t}#
+                                        |End Unit> take}.l := End (Unit : Unit) : <Cons {d : U8
+                                                                                        ,r : rec t}#
+                                                                                  |End Unit>
+                     end : rec t {l : <Cons {d : U8,r : rec t}#|End Unit>}
+                  end : rec t {l : <Cons {d : U8,r : rec t}#|End Unit>};

--- a/minigent/examples/6_recursive/01-basic/in.minigent
+++ b/minigent/examples/6_recursive/01-basic/in.minigent
@@ -1,6 +1,6 @@
-alloc : Unit -> mu t { l : < End Unit | Cons { d : U8, r : t }# > take };
+alloc : Unit -> rec t { l : < End Unit | Cons { d : U8, r : t }# > take };
 
-makeEmptyList : Unit -> mu t { l : < End Unit | Cons { d : U8, r : t }# > };
+makeEmptyList : Unit -> rec t { l : < End Unit | Cons { d : U8, r : t }# > };
 makeEmptyList a = 
             let r = alloc Unit in
                 put r.l := End Unit end

--- a/minigent/examples/6_recursive/02-poly/expected.out
+++ b/minigent/examples/6_recursive/02-poly/expected.out
@@ -1,18 +1,19 @@
 allocNode : [a]
             .
-            Unit -> mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit> take};
+            Unit -> rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit> take};
 createEmptyList : [a]
                   .
-                  U8 -> mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>};
+                  U8 -> rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>};
 createEmptyList a = let node = (allocNode[a] : Unit
-                                               -> mu t {l : <Cons {data : a
-                                                                  ,rest : rec t}#
-                                                            |Nil Unit> take}) (Unit : Unit) : mu t {l : <Cons {data : a
-                                                                                                              ,rest : rec t}#
-                                                                                                        |Nil Unit> take}
-                    in put node : mu t {l : <Cons {data : a,rest : rec t}#
-                                            |Nil Unit> take}.l := Nil (Unit : Unit) : <Cons {data : a
-                                                                                            ,rest : rec t}#
-                                                                                      |Nil Unit>
-                       end : mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}
-                    end : mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>};
+                                               -> rec t {l : <Cons {data : a
+                                                                   ,rest : rec t}#
+                                                             |Nil Unit> take}) (Unit : Unit) : rec t {l : <Cons {data : a
+                                                                                                                ,rest : rec t}#
+                                                                                                          |Nil Unit> take}
+                    in put node : rec t {l : <Cons {data : a,rest : rec t}#
+                                             |Nil Unit> take}.l := Nil (Unit : Unit) : <Cons {data : a
+                                                                                             ,rest : rec t}#
+                                                                                       |Nil Unit>
+                       end : rec t {l : <Cons {data : a,rest : rec t}#
+                                        |Nil Unit>}
+                    end : rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>};

--- a/minigent/examples/6_recursive/02-poly/in.minigent
+++ b/minigent/examples/6_recursive/02-poly/in.minigent
@@ -1,6 +1,6 @@
-allocNode : [a]. Unit -> mu t { l: < Nil Unit | Cons { data: a, rest: t }# > take };
+allocNode : [a]. Unit -> rec t { l: < Nil Unit | Cons { data: a, rest: t }# > take };
 
-createEmptyList : [a]. U8 -> mu t { l : < Nil Unit | Cons { data : a, rest : t }# >};
+createEmptyList : [a]. U8 -> rec t { l : < Nil Unit | Cons { data : a, rest : t }# >};
 createEmptyList a = 
     let node = allocNode Unit in
         put node.l := Nil Unit end

--- a/minigent/examples/6_recursive/03-non-strictly-positive/expected.err
+++ b/minigent/examples/6_recursive/03-non-strictly-positive/expected.err
@@ -1,2 +1,2 @@
 Reorg failed.
-Variables occuring non-strictly positive: t
+Recursive parameters occuring non-strictly positive: t

--- a/minigent/examples/6_recursive/03-non-strictly-positive/in.minigent
+++ b/minigent/examples/6_recursive/03-non-strictly-positive/in.minigent
@@ -1,2 +1,2 @@
-listop : Unit -> mu t { f : (t -> U8) };
+listop : Unit -> rec t { f : (t -> U8) };
 listop a = { f = End Unit };

--- a/minigent/examples/6_recursive/04-harder-non-strictly-positive/expected.err
+++ b/minigent/examples/6_recursive/04-harder-non-strictly-positive/expected.err
@@ -1,2 +1,2 @@
 Reorg failed.
-Variables occuring non-strictly positive: t
+Recursive parameters occuring non-strictly positive: t

--- a/minigent/examples/6_recursive/04-harder-non-strictly-positive/in.minigent
+++ b/minigent/examples/6_recursive/04-harder-non-strictly-positive/in.minigent
@@ -1,5 +1,5 @@
 listop : Unit -> 
-    mu t { 
+    rec t { 
         f : < Left U8 
             | Midde Unit 
             | Right { 

--- a/minigent/examples/6_recursive/05-strictly-positive-allowed/expected.out
+++ b/minigent/examples/6_recursive/05-strictly-positive-allowed/expected.out
@@ -1,3 +1,3 @@
-id : mu t {l : <End Unit|Rest {a : U8,b : rec t}>}
-     -> mu t {l : <End Unit|Rest {a : U8,b : rec t}>};
-id a = a : mu t {l : <End Unit|Rest {a : U8,b : rec t}>};
+id : rec t {l : <End Unit|Rest {a : U8,b : rec t}>}
+     -> rec t {l : <End Unit|Rest {a : U8,b : rec t}>};
+id a = a : rec t {l : <End Unit|Rest {a : U8,b : rec t}>};

--- a/minigent/examples/6_recursive/05-strictly-positive-allowed/in.minigent
+++ b/minigent/examples/6_recursive/05-strictly-positive-allowed/in.minigent
@@ -1,2 +1,2 @@
-id : mu t { l : < End Unit | Rest { a : U8, b : t } > } -> mu t { l : < End Unit | Rest { a : U8, b : t } > };
+id : rec t { l : < End Unit | Rest { a : U8, b : t } > } -> rec t { l : < End Unit | Rest { a : U8, b : t } > };
 id a = a;

--- a/minigent/examples/6_recursive/06-list-push/expected.out
+++ b/minigent/examples/6_recursive/06-list-push/expected.out
@@ -1,32 +1,32 @@
 allocNode : [a]
             .
-            Unit -> mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit> take};
+            Unit -> rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit> take};
 push : [a]
        .
-       {data : a,list : mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}}#
-       -> mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>};
+       {data : a,list : rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}}#
+       -> rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>};
 push r = let node = (allocNode[a] : Unit
-                                    -> mu t {l : <Cons {data : a,rest : rec t}#
-                                                 |Nil Unit> take}) (Unit : Unit) : mu t {l : <Cons {data : a
-                                                                                                   ,rest : rec t}#
-                                                                                             |Nil Unit> take}
+                                    -> rec t {l : <Cons {data : a,rest : rec t}#
+                                                  |Nil Unit> take}) (Unit : Unit) : rec t {l : <Cons {data : a
+                                                                                                     ,rest : rec t}#
+                                                                                               |Nil Unit> take}
          in take r2 { data = x } = r : {data : a
-                                       ,list : mu t {l : <Cons {data : a
-                                                               ,rest : rec t}#
-                                                         |Nil Unit>}}#
+                                       ,list : rec t {l : <Cons {data : a
+                                                                ,rest : rec t}#
+                                                          |Nil Unit>}}#
             in take r3 { list = y } = r2 : {data : a take
-                                           ,list : mu t {l : <Cons {data : a
-                                                                   ,rest : rec t}#
-                                                             |Nil Unit>}}#
-               in put node : mu t {l : <Cons {data : a,rest : rec t}#
-                                       |Nil Unit> take}.l := Cons ({data = x : a
-                                                                   ,rest = y : mu t {l : <Cons {data : a
-                                                                                               ,rest : rec t}#
-                                                                                         |Nil Unit>}} : {data : a
-                                                                                                        ,rest : rec t}#) : <Cons {data : a
-                                                                                                                                 ,rest : rec t}#
-                                                                                                                           |Nil Unit>
-                  end : mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}
-               end : mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}
-            end : mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}
-         end : mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>};
+                                           ,list : rec t {l : <Cons {data : a
+                                                                    ,rest : rec t}#
+                                                              |Nil Unit>}}#
+               in put node : rec t {l : <Cons {data : a,rest : rec t}#
+                                        |Nil Unit> take}.l := Cons ({data = x : a
+                                                                    ,rest = y : rec t {l : <Cons {data : a
+                                                                                                 ,rest : rec t}#
+                                                                                           |Nil Unit>}} : {data : a
+                                                                                                          ,rest : rec t}#) : <Cons {data : a
+                                                                                                                                   ,rest : rec t}#
+                                                                                                                             |Nil Unit>
+                  end : rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}
+               end : rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}
+            end : rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}
+         end : rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>};

--- a/minigent/examples/6_recursive/06-list-push/in.minigent
+++ b/minigent/examples/6_recursive/06-list-push/in.minigent
@@ -1,7 +1,7 @@
-allocNode : [a]. Unit -> mu t { l: < Nil Unit | Cons { data: a, rest: t }# > take };
+allocNode : [a]. Unit -> rec t { l: < Nil Unit | Cons { data: a, rest: t }# > take };
 
-push : [a]. { data: a, list: mu t { l: < Nil Unit | Cons { data: a, rest: t }# > } }#
-            -> mu t { l: < Nil Unit | Cons { data: a, rest: t }# >};
+push : [a]. { data: a, list: rec t { l: < Nil Unit | Cons { data: a, rest: t }# > } }#
+            -> rec t { l: < Nil Unit | Cons { data: a, rest: t }# >};
 push r = 
     let node = allocNode Unit in
         take r2 { data = x } = r in

--- a/minigent/examples/6_recursive/08-list-sum/expected.out
+++ b/minigent/examples/6_recursive/08-list-sum/expected.out
@@ -1,21 +1,21 @@
-sumList : mu t {l : <Cons {data : U32,rest : rec t!}#|Nil Unit>}! -> U32;
-sumList r = take r2 { l = z } = r : mu t {l : <Cons {data : U32,rest : rec t!}#
-                                              |Nil Unit>}!
+sumList : rec t {l : <Cons {data : U32,rest : rec t!}#|Nil Unit>}! -> U32;
+sumList r = take r2 { l = z } = r : rec t {l : <Cons {data : U32,rest : rec t!}#
+                                               |Nil Unit>}!
             in case z : <Cons {data : U32,rest : rec t!}#|Nil Unit> of
                  Nil u -> 0 : U32
                | v2 -> case v2 : <Cons {data : U32,rest : rec t!}#
                                  |Nil Unit take> of
                          Cons s -> take s2 { rest = x } = s : {data : U32
-                                                              ,rest : mu t {l : <Cons {data : U32
-                                                                                      ,rest : rec t!}#
-                                                                                |Nil Unit>}!}#
+                                                              ,rest : rec t {l : <Cons {data : U32
+                                                                                       ,rest : rec t!}#
+                                                                                 |Nil Unit>}!}#
                                    in ((s : {data : U32
-                                            ,rest : rec t!}#).data : U32) + ((sumList[  ] : mu t {l : <Cons {data : U32
-                                                                                                            ,rest : rec t!}#
-                                                                                                      |Nil Unit>}!
-                                                                                            -> U32) (x : mu t {l : <Cons {data : U32
-                                                                                                                         ,rest : rec t!}#
-                                                                                                                   |Nil Unit>}!) : U32) : U32
+                                            ,rest : rec t!}#).data : U32) + ((sumList[  ] : rec t {l : <Cons {data : U32
+                                                                                                             ,rest : rec t!}#
+                                                                                                       |Nil Unit>}!
+                                                                                            -> U32) (x : rec t {l : <Cons {data : U32
+                                                                                                                          ,rest : rec t!}#
+                                                                                                                    |Nil Unit>}!) : U32) : U32
                                    end : U32
                        end : U32
                end : U32

--- a/minigent/examples/6_recursive/08-list-sum/in.minigent
+++ b/minigent/examples/6_recursive/08-list-sum/in.minigent
@@ -1,4 +1,4 @@
-sumList : mu t { l: < Nil Unit | Cons { data: U32, rest: t! }# >}! -> U32;
+sumList : rec t { l: < Nil Unit | Cons { data: U32, rest: t! }# >}! -> U32;
 sumList r = 
   take r2 { l = z } = r in
     case z of

--- a/minigent/examples/6_recursive/09-map/expected.out
+++ b/minigent/examples/6_recursive/09-map/expected.out
@@ -1,86 +1,86 @@
-alloc : [x] . Unit -> mu t {l : <Cons {data : x,rest : rec t}#|Nil Unit> take};
+alloc : [x] . Unit -> rec t {l : <Cons {data : x,rest : rec t}#|Nil Unit> take};
 map : [a, b]
       .
-      {f : a -> b,list : mu t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}!}#
-      -> mu t {l : <Cons {data : b,rest : rec t}#|Nil Unit>};
+      {f : a -> b,list : rec t {l : <Cons {data : a,rest : rec t}#|Nil Unit>}!}#
+      -> rec t {l : <Cons {data : b,rest : rec t}#|Nil Unit>};
 map l = take l2 { list = node } = l : {f : a -> b
-                                      ,list : mu t {l : <Cons {data : a
-                                                              ,rest : rec t}#
-                                                        |Nil Unit>}!}#
-        in take l3 { f = fun } = l2 : {f : a -> b
-                                      ,list : mu t {l : <Cons {data : a
-                                                              ,rest : rec t}#
-                                                        |Nil Unit>}! take}#
-           in take node2 { l = head } = node : mu t {l : <Cons {data : a
+                                      ,list : rec t {l : <Cons {data : a
                                                                ,rest : rec t}#
-                                                         |Nil Unit>}!
+                                                         |Nil Unit>}!}#
+        in take l3 { f = fun } = l2 : {f : a -> b
+                                      ,list : rec t {l : <Cons {data : a
+                                                               ,rest : rec t}#
+                                                         |Nil Unit>}! take}#
+           in take node2 { l = head } = node : rec t {l : <Cons {data : a
+                                                                ,rest : rec t}#
+                                                          |Nil Unit>}!
               in case head : <Cons {data : a,rest : rec t}#|Nil Unit> of
                    Nil u -> let newNode = (alloc[b] : Unit
-                                                      -> mu t {l : <Cons {data : b
-                                                                         ,rest : rec t}#
-                                                                   |Nil Unit> take}) (Unit : Unit) : mu t {l : <Cons {data : b
-                                                                                                                     ,rest : rec t}#
-                                                                                                               |Nil Unit> take}
-                            in put newNode : mu t {l : <Cons {data : b
-                                                             ,rest : rec t}#
-                                                       |Nil Unit> take}.l := Nil (Unit : Unit) : <Cons {data : b
-                                                                                                       ,rest : rec t}#
-                                                                                                 |Nil Unit>
-                               end : mu t {l : <Cons {data : b,rest : rec t}#
-                                               |Nil Unit>}
-                            end : mu t {l : <Cons {data : b,rest : rec t}#
-                                            |Nil Unit>}
+                                                      -> rec t {l : <Cons {data : b
+                                                                          ,rest : rec t}#
+                                                                    |Nil Unit> take}) (Unit : Unit) : rec t {l : <Cons {data : b
+                                                                                                                       ,rest : rec t}#
+                                                                                                                 |Nil Unit> take}
+                            in put newNode : rec t {l : <Cons {data : b
+                                                              ,rest : rec t}#
+                                                        |Nil Unit> take}.l := Nil (Unit : Unit) : <Cons {data : b
+                                                                                                        ,rest : rec t}#
+                                                                                                  |Nil Unit>
+                               end : rec t {l : <Cons {data : b,rest : rec t}#
+                                                |Nil Unit>}
+                            end : rec t {l : <Cons {data : b,rest : rec t}#
+                                             |Nil Unit>}
                  | v2 -> case v2 : <Cons {data : a,rest : rec t}#
                                    |Nil Unit take> of
                            Cons remaining -> take remaining2 { data = x } = remaining : {data : a
                                                                                         ,rest : rec t}#
                                              in let newNode = (alloc[b] : Unit
-                                                                          -> mu t {l : <Cons {data : b
-                                                                                             ,rest : rec t}#
-                                                                                       |Nil Unit> take}) (Unit : Unit) : mu t {l : <Cons {data : b
-                                                                                                                                         ,rest : rec t}#
-                                                                                                                                   |Nil Unit> take}
-                                                in put newNode : mu t {l : <Cons {data : b
-                                                                                 ,rest : rec t}#
-                                                                           |Nil Unit> take}.l := Cons ({data = (fun : a
-                                                                                                                      -> b) (x : a) : b
-                                                                                                       ,rest = (map[ a
-                                                                                                                   , b ] : {f : a
-                                                                                                                                -> b
-                                                                                                                           ,list : mu t {l : <Cons {data : a
-                                                                                                                                                   ,rest : rec t}#
-                                                                                                                                             |Nil Unit>}!}#
-                                                                                                                           -> mu t {l : <Cons {data : b
-                                                                                                                                              ,rest : rec t}#
-                                                                                                                                        |Nil Unit>}) ({list = (remaining2 : {data : a take
-                                                                                                                                                                            ,rest : mu t {l : <Cons {data : a
+                                                                          -> rec t {l : <Cons {data : b
+                                                                                              ,rest : rec t}#
+                                                                                        |Nil Unit> take}) (Unit : Unit) : rec t {l : <Cons {data : b
+                                                                                                                                           ,rest : rec t}#
+                                                                                                                                     |Nil Unit> take}
+                                                in put newNode : rec t {l : <Cons {data : b
+                                                                                  ,rest : rec t}#
+                                                                            |Nil Unit> take}.l := Cons ({data = (fun : a
+                                                                                                                       -> b) (x : a) : b
+                                                                                                        ,rest = (map[ a
+                                                                                                                    , b ] : {f : a
+                                                                                                                                 -> b
+                                                                                                                            ,list : rec t {l : <Cons {data : a
+                                                                                                                                                     ,rest : rec t}#
+                                                                                                                                               |Nil Unit>}!}#
+                                                                                                                            -> rec t {l : <Cons {data : b
+                                                                                                                                                ,rest : rec t}#
+                                                                                                                                          |Nil Unit>}) ({list = (remaining2 : {data : a take
+                                                                                                                                                                              ,rest : rec t {l : <Cons {data : a
+                                                                                                                                                                                                       ,rest : rec t}#
+                                                                                                                                                                                                 |Nil Unit>}!}#).rest : rec t {l : <Cons {data : a
+                                                                                                                                                                                                                                         ,rest : rec t}#
+                                                                                                                                                                                                                                   |Nil Unit>}!
+                                                                                                                                                        ,f = fun : a
+                                                                                                                                                                   -> b} : {f : a
+                                                                                                                                                                                -> b
+                                                                                                                                                                           ,list : rec t {l : <Cons {data : a
                                                                                                                                                                                                     ,rest : rec t}#
-                                                                                                                                                                                              |Nil Unit>}!}#).rest : mu t {l : <Cons {data : a
-                                                                                                                                                                                                                                     ,rest : rec t}#
-                                                                                                                                                                                                                               |Nil Unit>}!
-                                                                                                                                                      ,f = fun : a
-                                                                                                                                                                 -> b} : {f : a
-                                                                                                                                                                              -> b
-                                                                                                                                                                         ,list : mu t {l : <Cons {data : a
-                                                                                                                                                                                                 ,rest : rec t}#
-                                                                                                                                                                                           |Nil Unit>}!}#) : mu t {l : <Cons {data : b
-                                                                                                                                                                                                                             ,rest : rec t}#
-                                                                                                                                                                                                                       |Nil Unit>}} : {data : b
-                                                                                                                                                                                                                                      ,rest : rec t}#) : <Cons {data : b
-                                                                                                                                                                                                                                                               ,rest : rec t}#
-                                                                                                                                                                                                                                                         |Nil Unit>
-                                                   end : mu t {l : <Cons {data : b
-                                                                         ,rest : rec t}#
-                                                                   |Nil Unit>}
-                                                end : mu t {l : <Cons {data : b
-                                                                      ,rest : rec t}#
-                                                                |Nil Unit>}
-                                             end : mu t {l : <Cons {data : b
-                                                                   ,rest : rec t}#
-                                                             |Nil Unit>}
-                         end : mu t {l : <Cons {data : b,rest : rec t}#
-                                         |Nil Unit>}
-                 end : mu t {l : <Cons {data : b,rest : rec t}#|Nil Unit>}
-              end : mu t {l : <Cons {data : b,rest : rec t}#|Nil Unit>}
-           end : mu t {l : <Cons {data : b,rest : rec t}#|Nil Unit>}
-        end : mu t {l : <Cons {data : b,rest : rec t}#|Nil Unit>};
+                                                                                                                                                                                              |Nil Unit>}!}#) : rec t {l : <Cons {data : b
+                                                                                                                                                                                                                                 ,rest : rec t}#
+                                                                                                                                                                                                                           |Nil Unit>}} : {data : b
+                                                                                                                                                                                                                                          ,rest : rec t}#) : <Cons {data : b
+                                                                                                                                                                                                                                                                   ,rest : rec t}#
+                                                                                                                                                                                                                                                             |Nil Unit>
+                                                   end : rec t {l : <Cons {data : b
+                                                                          ,rest : rec t}#
+                                                                    |Nil Unit>}
+                                                end : rec t {l : <Cons {data : b
+                                                                       ,rest : rec t}#
+                                                                 |Nil Unit>}
+                                             end : rec t {l : <Cons {data : b
+                                                                    ,rest : rec t}#
+                                                              |Nil Unit>}
+                         end : rec t {l : <Cons {data : b,rest : rec t}#
+                                          |Nil Unit>}
+                 end : rec t {l : <Cons {data : b,rest : rec t}#|Nil Unit>}
+              end : rec t {l : <Cons {data : b,rest : rec t}#|Nil Unit>}
+           end : rec t {l : <Cons {data : b,rest : rec t}#|Nil Unit>}
+        end : rec t {l : <Cons {data : b,rest : rec t}#|Nil Unit>};

--- a/minigent/examples/6_recursive/09-map/in.minigent
+++ b/minigent/examples/6_recursive/09-map/in.minigent
@@ -1,7 +1,7 @@
-alloc : [x]. Unit -> mu t { l: < Nil Unit | Cons { data: x, rest: t }# > take };
+alloc : [x]. Unit -> rec t { l: < Nil Unit | Cons { data: x, rest: t }# > take };
 
-map : [a,b]. { list: mu t { l: < Nil Unit | Cons { data: a, rest: t }# > }!, f: (a -> b) }#
-              -> mu t { l: < Nil Unit | Cons { data: b, rest: t }# >};
+map : [a,b]. { list: rec t { l: < Nil Unit | Cons { data: a, rest: t }# > }!, f: (a -> b) }#
+              -> rec t { l: < Nil Unit | Cons { data: b, rest: t }# >};
 map l = 
   take l2 { list = node } = l in
     take l3 { f = fun } = l2 in

--- a/minigent/examples/6_recursive/10-bang-incompatible/expected.out
+++ b/minigent/examples/6_recursive/10-bang-incompatible/expected.out
@@ -1,1 +1,1 @@
-bad : mu k {f : <Chain rec k!|Some U8>} -> mu k {f : <Chain rec k|Some U8>};
+bad : rec k {f : <Chain rec k!|Some U8>} -> rec k {f : <Chain rec k|Some U8>};

--- a/minigent/examples/6_recursive/10-bang-incompatible/in.minigent
+++ b/minigent/examples/6_recursive/10-bang-incompatible/in.minigent
@@ -1,3 +1,3 @@
-bad: mu k { f: < Some U8 | Chain k! > } 
-    -> mu k { f: < Some U8 | Chain k > };
+bad: rec k { f: < Some U8 | Chain k! > } 
+    -> rec k { f: < Some U8 | Chain k > };
 bad x = x;

--- a/minigent/examples/6_recursive/11-incompatible-recpars/expected.err
+++ b/minigent/examples/6_recursive/11-incompatible-recpars/expected.err
@@ -1,7 +1,7 @@
 Typecheck failed in function incompatible
- •  mu t {f : <Leaf Unit
-              |Node {data : U64
-                    ,left : rec t
-                    ,right : rec t}#>} :< mu t {l : <Cons {data : U64
-                                                          ,rest : rec t}#
-                                                    |Nil Unit>}
+ •  rec t {f : <Leaf Unit
+               |Node {data : U64
+                     ,left : rec t
+                     ,right : rec t}#>} :< rec t {l : <Cons {data : U64
+                                                            ,rest : rec t}#
+                                                      |Nil Unit>}

--- a/minigent/examples/6_recursive/11-incompatible-recpars/expected.out
+++ b/minigent/examples/6_recursive/11-incompatible-recpars/expected.out
@@ -1,6 +1,6 @@
-deallocList : mu t {l : <Cons {data : U64,rest : rec t}#|Nil Unit>} -> Unit;
+deallocList : rec t {l : <Cons {data : U64,rest : rec t}#|Nil Unit>} -> Unit;
 genTree : Unit
-          -> mu t {f : <Leaf Unit
-                       |Node {data : U64,left : rec t,right : rec t}#>};
-incompatible : mu t {l : <Cons {data : U64,rest : rec t}#|Nil Unit>}
-               -> mu t {l : <Cons {data : U64,rest : rec t}#|Nil Unit>};
+          -> rec t {f : <Leaf Unit
+                        |Node {data : U64,left : rec t,right : rec t}#>};
+incompatible : rec t {l : <Cons {data : U64,rest : rec t}#|Nil Unit>}
+               -> rec t {l : <Cons {data : U64,rest : rec t}#|Nil Unit>};

--- a/minigent/examples/6_recursive/11-incompatible-recpars/in.minigent
+++ b/minigent/examples/6_recursive/11-incompatible-recpars/in.minigent
@@ -1,9 +1,9 @@
-genTree : Unit -> mu t { f: < Leaf Unit | Node { left: t, right: t, data: U64 }# > };
+genTree : Unit -> rec t { f: < Leaf Unit | Node { left: t, right: t, data: U64 }# > };
 
-deallocList: mu t { l: < Nil Unit | Cons { data: U64, rest: t }# > } -> Unit;
+deallocList: rec t { l: < Nil Unit | Cons { data: U64, rest: t }# > } -> Unit;
 
-incompatible : mu t { l: < Nil Unit | Cons { data: U64, rest: t }# > } 
-            -> mu t { l: < Nil Unit | Cons { data: U64, rest: t }# > };
+incompatible : rec t { l: < Nil Unit | Cons { data: U64, rest: t }# > } 
+            -> rec t { l: < Nil Unit | Cons { data: U64, rest: t }# > };
 incompatible list =
   take emptyList { l = node } = list in
     case node of

--- a/minigent/examples/6_recursive/12-alpha-equivalent-recpars/in.minigent
+++ b/minigent/examples/6_recursive/12-alpha-equivalent-recpars/in.minigent
@@ -1,0 +1,2 @@
+f : rec t { l: < Zero Unit | Succ t > } -> rec k { l: < Zero Unit | Succ k > };
+f peano = peano;

--- a/minigent/src/Minigent/CLI.hs
+++ b/minigent/src/Minigent/CLI.hs
@@ -194,7 +194,7 @@ reorgPhase x =
   in case errs of
        []   -> pure envs
        errs -> do
-         die ("Reorg failed.\n" ++ unlines errs ++ "\n\n")
+         die ("Reorg failed.\n" ++ unlines errs)
 
 tcPhase :: Bool -> GlobalEnvironments -> IO GlobalEnvironments
 tcPhase colour envs

--- a/minigent/src/Minigent/Reorganiser.hs
+++ b/minigent/src/Minigent/Reorganiser.hs
@@ -106,7 +106,7 @@ sanityCheckExpr envs tvs vs exp = check vs exp
       e           -> pure e
 
 reorganiseTopLevel :: RawTopLevel -> GlobalEnvironments -> Writer [Error] GlobalEnvironments
-reorganiseTopLevel (TypeSig f pt@(Forall _ _ t)) envs = do 
+reorganiseTopLevel (TypeSig f pt) envs = do 
   case M.lookup f (types envs) of 
     Just _ -> tell ["Duplicate type signature for " ++ f] 
     Nothing -> return ()
@@ -155,8 +155,6 @@ embedRecPars (Forall vs cs t) = Forall vs cs $ erp False M.empty t
     erp _ _ t = t
 
 -- | Checks that variables only occur strictly positive.
---   We check the argument and result of the function seperately so as not to
---   trigger the strictly positive case for everything that is an argument.
 nonStrictlyPositiveVars :: Type -> [VarName] 
 nonStrictlyPositiveVars t = sp t M.empty
   where

--- a/minigent/src/Minigent/Syntax/Lexer.hs
+++ b/minigent/src/Minigent/Syntax/Lexer.hs
@@ -25,7 +25,7 @@ data Bracket = Paren | Brace | Square
      deriving (Show, Eq)
 
 
-data Keyword = Case | Of | If | Then | Else | Take | Put | Let | In | End | Mu
+data Keyword = Case | Of | If | Then | Else | Take | Put | Let | In | End | Rec
      deriving (Show, Eq)
 
 data Token
@@ -61,7 +61,7 @@ toToken "take" = Keyword Take
 toToken "put"  = Keyword Put 
 toToken "let"  = Keyword Let
 toToken "in"   = Keyword In 
-toToken "mu"   = Keyword Mu
+toToken "rec"   = Keyword Rec
 toToken (x:xs) | isLower x = LowerIdent (x:xs)
                | otherwise = UpperIdent (x:xs)  
 

--- a/minigent/src/Minigent/Syntax/Parser.hs
+++ b/minigent/src/Minigent/Syntax/Parser.hs
@@ -250,8 +250,8 @@ toplevel = mdo
                     <|> (:[]) <$> typeVar
                     <|> pure []
     
-                -- mu t
-    recTy <- rule $ Rec <$> (token (L.Keyword L.Mu) *> typeVar)
+                -- rec t
+    recTy <- rule $ Rec <$> (token (L.Keyword L.Rec) *> typeVar)
                 -- recursive parameter ommitted
                  <|> pure None 
                  <?> "recursive type"

--- a/minigent/src/Minigent/Syntax/PrettyPrint.hs
+++ b/minigent/src/Minigent/Syntax/PrettyPrint.hs
@@ -49,7 +49,7 @@ prettySigil (UnknownSigil s)  = annotate S.sigil (pretty s)
 prettySigil _ = mempty
 
 prettyRecPar None                 = mempty
-prettyRecPar (Rec x)              = annotate S.typeVar (annotate S.keyword "mu" <+> pretty x) <+> mempty
+prettyRecPar (Rec x)              = annotate S.typeVar (annotate S.keyword "rec" <+> pretty x) <+> mempty
 prettyRecPar (UnknownParameter x) = annotate S.unifVar (pretty x) <+> mempty
 
 prettyVRow r@(Row _ Nothing)  = encloseSep langle rangle pipe (map prettyVEntry (Row.entries r))
@@ -207,7 +207,8 @@ prettySimpleConstraint c = case c of
   (t1 :=:   t2) -> prettyType t1 <+> annotate S.constraintKeyword ":=:" <+> prettyType t2
   (Sat)         -> annotate S.constraintKeyword "Sat"
   (Unsat)       -> annotate S.constraintKeyword "Unsat"
-  (UnboxedNoRecurse t)       -> annotate S.constraintKeyword "UnboxedNoRecurse" <+> prettyType t
+  (UnboxedNoRecurse rp s)
+                -> annotate S.constraintKeyword "UnboxedNoRecurse" <+> parens (prettyRecPar rp) <+> parens (prettySigil s)
   _             -> error "prettySimpleConstraint called on non-simple constraint"
 
 prettyConstraint cs  = vsep (punctuate (space <> annotate S.constraintKeyword ":&:")

--- a/minigent/src/Minigent/Syntax/Utils.hs
+++ b/minigent/src/Minigent/Syntax/Utils.hs
@@ -278,7 +278,6 @@ sameRecursive _       _       = False
 -- | Unrolls a recursive parameter to the record it references
 unroll :: RecParName -> RecContext -> Type
 unroll n (Just ctxt) = mapRecPars (Just ctxt)  (ctxt M.! n)
--- TODO: Should this be an error?
 unroll _ _ = error "Impossible: cannot unroll a recursive parameter with an empty context"
 
 -- | Given a context, changes all recursive parameter references from TypeVar to RecPar according to the context

--- a/minigent/src/Minigent/TC/ConstraintGen.hs
+++ b/minigent/src/Minigent/TC/ConstraintGen.hs
@@ -199,7 +199,7 @@ cg e tau = case e of
     sigil  <- fresh
     recPar <- UnknownParameter <$> fresh
     let alpha = Record recPar row (UnknownSigil sigil)
-    let c0    = UnboxedNoRecurse alpha
+    let c0    = UnboxedNoRecurse recPar (UnknownSigil sigil)
 
     (e1', c1) <- cg e1 alpha
     modify (push (y, beta))
@@ -223,7 +223,7 @@ cg e tau = case e of
     (e1', c1) <- cg e1 alpha
     (e2', c2) <- cg e2 beta
 
-    let c0 = UnboxedNoRecurse alpha
+    let c0 = UnboxedNoRecurse recPar (UnknownSigil sigil)
 
     let c3 = Record recPar (Row.put f row) (UnknownSigil sigil) :< tau
 

--- a/minigent/src/Minigent/TC/ConstraintGen.hs
+++ b/minigent/src/Minigent/TC/ConstraintGen.hs
@@ -185,8 +185,6 @@ cg e tau = case e of
     row <- Row.incomplete [Entry f tau False]
     sigil <- fresh
     recPar <- UnknownParameter <$> fresh
-    -- TODO: Member is supposed to be on nonlinear records, will these ever have a recursive parameter
-    -- (i.e. are they *always* unboxed records?)
     let alpha = Record recPar row (UnknownSigil sigil)
     (e', c1) <- cg e alpha
     let c2 = Drop (Record recPar (Row.take f row) (UnknownSigil sigil))

--- a/minigent/src/Minigent/TC/Equate.hs
+++ b/minigent/src/Minigent/TC/Equate.hs
@@ -89,8 +89,7 @@ findEquateCandidates mentions (c:cs) = let
                        , Row.justVar r1 
                        , canEquate fst a t
                       -> (c:sups, subs, others)
-      -- TODO: Rethink record equation with recpars
-       Record n r1 s :< t | Just a <- rowVar r1
+       Record rp r1 s :< t | Just a <- rowVar r1
                         , Row.justVar r1
                         , canEquate fst a t
                        -> (c:sups, subs, others)
@@ -98,7 +97,7 @@ findEquateCandidates mentions (c:cs) = let
                        , Row.justVar r1
                        , canEquate snd a t
                       -> (sups, c : subs, others)
-       t :< Record n r1 s | Just a <- rowVar r1
+       t :< Record rp r1 s | Just a <- rowVar r1
                         , Row.justVar r1
                         , canEquate snd a t
                        -> (sups, c : subs, others)

--- a/minigent/src/Minigent/TC/JoinMeet.hs
+++ b/minigent/src/Minigent/TC/JoinMeet.hs
@@ -35,8 +35,6 @@ data Candidate = Meet Type Type Type
 joinMeet :: (Monad m, MonadFresh VarName m) => Rewrite.Rewrite' m [Constraint]
 joinMeet = Rewrite.withTransform find $ \c -> case c of
 
--- TODO: Fix this
-
   Meet v (Function t1 t2) (Function r1 r2) -> do
     b1 <- UnifVar <$> fresh
     b2 <- UnifVar <$> fresh
@@ -80,9 +78,8 @@ joinMeet = Rewrite.withTransform find $ \c -> case c of
     n <- UnknownParameter <$> fresh
     pure [Record n r s :< v, Record n1 r1 s1 :< Record n r s, Record n2 r2 s2 :< Record n r s]
 
-  -- TODO: Check if the recursive parameters need to be compared?
-  Join v (Record n1 r1 s1) (Record n2 r2 s2) | r1 == r2 && s1 == s2 && n1 == n2 -> do
-    pure [Record n1 r1 s1 :< v]
+  Join v (Record rp1 r1 s1) (Record rp2 r2 s2) | r1 == r2 && s1 == s2 && sameRecursive rp1 rp2 -> do
+    pure [Record rp1 r1 s1 :< v]
 
   Join v (Function t1 t2) (Function r1 r2) -> do
     b1 <- UnifVar <$> fresh

--- a/minigent/src/Minigent/TC/Normalise.hs
+++ b/minigent/src/Minigent/TC/Normalise.hs
@@ -17,21 +17,16 @@ import qualified Minigent.Syntax.Utils.Row as Row
 
 import qualified Data.Map as M
 
-
--- TODO: Remove
-import Debug.Trace
-import Minigent.Syntax.PrettyPrint
-
 normaliseRW :: Rewrite Type
 normaliseRW = rewrite $ \t -> --trace ("Norm about to look at type:\n" ++ debugPrettyType t) $ 
   case t of
-    Bang (Function t1 t2)  -> Just (Function t1 t2)
-    Bang (AbsType n s ts)  -> Just (AbsType n (bangSigil s) (map Bang ts))
-    Bang (TypeVar a)       -> Just (TypeVarBang a)
-    Bang (TypeVarBang a)   -> Just (TypeVarBang a)
-    Bang (RecPar a ctxt)        -> Just (RecParBang a ctxt)
-    Bang (RecParBang a ctxt)    -> Just (RecParBang a ctxt)
-    Bang (PrimType t)      -> Just (PrimType t)
+    Bang (Function t1 t2)    -> Just (Function t1 t2)
+    Bang (AbsType n s ts)    -> Just (AbsType n (bangSigil s) (map Bang ts))
+    Bang (TypeVar a)         -> Just (TypeVarBang a)
+    Bang (TypeVarBang a)     -> Just (TypeVarBang a)
+    Bang (RecPar a ctxt)     -> Just (RecParBang a ctxt)
+    Bang (RecParBang a ctxt) -> Just (RecParBang a ctxt)
+    Bang (PrimType t)        -> Just (PrimType t)
     Bang (Variant r)  | rowVar r == Nothing
       -> Just (Variant (Row.mapEntries (entryTypes Bang) r))
     Bang (Record n r s) | rowVar r == Nothing, s == ReadOnly || s == Writable || s == Unboxed

--- a/minigent/src/Minigent/TC/Simplify.hs
+++ b/minigent/src/Minigent/TC/Simplify.hs
@@ -104,12 +104,21 @@ simplify axs = Rewrite.pickOne $ \c -> -- trace ("About to simpliy:\n" ++ debugP
   {-
    - Recursive Parameters:
    - If we are reasoning about two recursive parameters, check if their context references
-   - are equal
+   - are equal. We *do not* unroll here, and if we arrive at the same position where the contexts
+   - are both `Nothing', then the RecPars are truly equal.
+   -
+   - N.B. recursive parameters need only be *alpha* equivalent, hence we do not check if the names are equal
    -}
-  RecPar n ctxt :< RecPar n' ctxt'  -> guard (ctxt M.! n == ctxt M.! n') >> Just []
-  RecPar n ctxt :=: RecPar n' ctxt' -> guard (ctxt M.! n == ctxt M.! n') >> Just []
-  RecParBang n ctxt :< RecParBang n' ctxt'  -> guard (ctxt M.! n == ctxt M.! n') >> Just []
-  RecParBang n ctxt :=: RecParBang n' ctxt' -> guard (ctxt M.! n == ctxt M.! n') >> Just []
+  RecPar n     (Just ctxt) :<  RecPar n'     (Just ctxt') -> Just [(ctxt M.! n) :<  (ctxt M.! n')]
+  RecPar n     (Just ctxt) :=: RecPar n'     (Just ctxt') -> Just [(ctxt M.! n) :=: (ctxt M.! n')]
+  RecParBang n (Just ctxt) :<  RecParBang n' (Just ctxt') -> Just [(ctxt M.! n) :<  (ctxt M.! n')]
+  RecParBang n (Just ctxt) :=: RecParBang n' (Just ctxt') -> Just [(ctxt M.! n) :=: (ctxt M.! n')]
+
+  RecPar n     Nothing :<  RecPar n'     Nothing -> Just []
+  RecPar n     Nothing :=: RecPar n'     Nothing -> Just []
+  RecParBang n Nothing :<  RecParBang n' Nothing -> Just []
+  RecParBang n Nothing :=: RecParBang n' Nothing -> Just []
+
 
   -- We need this here as otherwise it triggers the cases below
   RecParBang n ctxt :< RecPar n' ctxt'  ->  Nothing 
@@ -122,15 +131,15 @@ simplify axs = Rewrite.pickOne $ \c -> -- trace ("About to simpliy:\n" ++ debugP
    - If we are reasoning about a recursive parameter and a type, unroll the parameter
    - and reason about the type and the unrolled parameter
    -}
-  RecPar n ctxt :< t  -> Just [ unroll (RecPar n ctxt) :< t]
-  t :< RecPar n ctxt  -> Just [t :< unroll (RecPar n ctxt)]
-  RecPar n ctxt :=: t -> Just [unroll (RecPar n ctxt) :=: t]
-  t :=: RecPar n ctxt -> Just [t :=: unroll (RecPar n ctxt)]
+  RecPar n ctxt :< t  -> Just [unroll n ctxt :< t]
+  t :< RecPar n ctxt  -> Just [t :< unroll n ctxt]
+  RecPar n ctxt :=: t -> Just [unroll n ctxt :=: t]
+  t :=: RecPar n ctxt -> Just [t :=: unroll n ctxt]
 
-  RecParBang n ctxt :< t  -> Just [Bang (unroll (RecPar n ctxt)) :< t]
-  t :< RecParBang n ctxt  -> Just [t :< Bang (unroll (RecPar n ctxt))]
-  RecParBang n ctxt :=: t -> Just [Bang (unroll (RecPar n ctxt)) :=: t]
-  t :=: RecParBang n ctxt -> Just [t :=: Bang (unroll (RecPar n ctxt))]
+  RecParBang n ctxt :< t  -> Just [Bang (unroll n ctxt) :< t]
+  t :< RecParBang n ctxt  -> Just [t :< Bang (unroll n ctxt)]
+  RecParBang n ctxt :=: t -> Just [Bang (unroll n ctxt) :=: t]
+  t :=: RecParBang n ctxt -> Just [t :=: Bang (unroll n ctxt)]
 
   t :< t'  -> guard (unorderedType t || unorderedType t') >> Just [t :=: t']
 
@@ -150,10 +159,10 @@ simplify axs = Rewrite.pickOne $ \c -> -- trace ("About to simpliy:\n" ++ debugP
         c   = Variant r1' :=: Variant r2'
     Just (c:cs)
 
-  Record n1 r1 s1   :=: Record n2 r2 s2 ->
-    if Row.null r1 && Row.null r2 && s1 == s2 && n1 == n2 then Just []
-    else if Row.justVar r1 && Row.justVar r2 && s1 == s2 && r1 == r2 && n1 == n2
-         then Just [Solved (Record n1 r1 s1)]
+  Record rp1 r1 s1   :=: Record rp2 r2 s2 ->
+    if Row.null r1 && Row.null r2 && s1 == s2 && sameRecursive rp1 rp2 then Just []
+    else if Row.justVar r1 && Row.justVar r2 && s1 == s2 && r1 == r2 && sameRecursive rp1 rp2
+         then Just [Solved (Record rp1 r1 s1)]
     else do
     let commons  = Row.common r1 r2
         (ls, rs) = unzip commons
@@ -161,7 +170,7 @@ simplify axs = Rewrite.pickOne $ \c -> -- trace ("About to simpliy:\n" ++ debugP
     guard (untakenLabels rs == untakenLabels ls)
     let (r1',r2') = Row.withoutCommon r1 r2
         cs = map (\(Entry _ t _, Entry _ t' _) -> t :=: t') commons
-        c   = Record n1 r1' s1 :=: Record n2 r2' s2
+        c   = Record rp1 r1' s1 :=: Record rp2 r2' s2
     Just (c:cs)
     
   t :=: t' -> guard (t == t') >> if typeUVs t == [] then Just [] 
@@ -169,9 +178,9 @@ simplify axs = Rewrite.pickOne $ \c -> -- trace ("About to simpliy:\n" ++ debugP
   Solved t -> guard (typeUVs t == []) >> Just []
 
   -- If an unboxed record has no recursive parameter, sat
-  UnboxedNoRecurse (Record None _ Unboxed) -> Just []
+  UnboxedNoRecurse None Unboxed -> Just []
   -- If a boxed record, sat
-  UnboxedNoRecurse (Record _ _ c) | (c == ReadOnly || c == Writable) -> Just []
+  UnboxedNoRecurse _ c | (c == ReadOnly || c == Writable) -> Just []
 
   _ -> Nothing
 

--- a/minigent/src/Minigent/TC/Unify.hs
+++ b/minigent/src/Minigent/TC/Unify.hs
@@ -55,11 +55,6 @@ assignOf (Record _ _ s :< Record _ _ (UnknownSigil v))
   | s `elem` [ReadOnly, Unboxed, Writable]
   = pure [ SigilAssign v s ]
 
--- TODO: Check this
-assignOf (Record (UnknownParameter x) _ s :< Record _ _ Unboxed) 
-  = pure [RecParAssign x None]
-
-
 -- N.B. we know from the previous phase that common alternatives have been factored out.
 assignOf (Variant r1 :=: Variant r2)
   | rowVar r1 /= rowVar r2

--- a/minigent/src/Minigent/TC/Unify.hs
+++ b/minigent/src/Minigent/TC/Unify.hs
@@ -54,8 +54,12 @@ assignOf (Record _ _ (UnknownSigil v) :< Record _ _ s)
 assignOf (Record _ _ s :< Record _ _ (UnknownSigil v))
   | s `elem` [ReadOnly, Unboxed, Writable]
   = pure [ SigilAssign v s ]
+
+-- TODO: Check this
 assignOf (Record (UnknownParameter x) _ s :< Record _ _ Unboxed) 
   = pure [RecParAssign x None]
+
+
 -- N.B. we know from the previous phase that common alternatives have been factored out.
 assignOf (Variant r1 :=: Variant r2)
   | rowVar r1 /= rowVar r2
@@ -80,7 +84,6 @@ assignOf (Record _ r1 s1 :=: Record _ r2 s2)
                                  , RowAssign y (r1 { rowVar = Just v })
                                  ]
 
--- TODO: Generalise
 assignOf (Record n1 _ _ :=: Record n2 _ _)
   = case (n1,n2) of
       (Rec _, UnknownParameter x) -> pure [RecParAssign x n1]
@@ -89,17 +92,17 @@ assignOf (Record n1 _ _ :=: Record n2 _ _)
       (None, UnknownParameter x)  -> pure [RecParAssign x None]
       _              -> empty 
 
-assignOf (Record n1 _ _ :< Record n2 _ _)
-  = case (n1,n2) of
-      (Rec _, UnknownParameter x) -> pure [RecParAssign x n1]
-      (UnknownParameter x, Rec _) -> pure [RecParAssign x n2]
+assignOf (Record rp1 _ _ :< Record rp2 _ _)
+  = case (rp1,rp2) of
+      (Rec _, UnknownParameter x) -> pure [RecParAssign x rp1]
+      (UnknownParameter x, Rec _) -> pure [RecParAssign x rp2]
       (UnknownParameter x, None)  -> pure [RecParAssign x None]
       (None, UnknownParameter x)  -> pure [RecParAssign x None]
       _              -> empty 
 
--- If it is discovered that a record is unboxed, we can assign it's
--- unknown parameter to None
-assignOf (UnboxedNoRecurse (Record (UnknownParameter x) _ Unboxed))
+-- If it is discovered that a sigil is unboxed, we can assign it's
+--  unknown parameter to None
+assignOf (UnboxedNoRecurse (UnknownParameter x) Unboxed)
     = pure [RecParAssign x None]
 
 assignOf _ = empty


### PR DESCRIPTION
* Recursive types now implemented as per changes in main compiler (alpha equivalence for recursive parameters, use of recursive context)
* Termination checking is a little cleaner
* All TODO's cleaned up
* Termination now labels the output graph with 'argument' and 'goal' labels like so:

![image](https://user-images.githubusercontent.com/19238087/73911981-6ec19300-4907-11ea-8560-72b9bf5337dd.png)