### PR TITLE
fix parser for layout expression

### DIFF
--- a/cogent/src/Cogent/PrettyPrint.hs
+++ b/cogent/src/Cogent/PrettyPrint.hs
@@ -681,7 +681,7 @@ instance Pretty DataLayoutSize where
   pretty (Add a b) = pretty a <+> symbol "+" <+> pretty b
 
 instance Pretty d => Pretty (DataLayoutExpr' d) where
-  pretty (RepRef n s) = reprname n <+> hsep (fmap pretty s)
+  pretty (RepRef n s) = if null s then reprname n else parens $ reprname n <+> hsep (fmap pretty s)
   pretty (Prim sz) = pretty sz
   pretty (Offset e s) = pretty e <+> keyword "at" <+> pretty s
   pretty (Record fs) = keyword "record" <+> record (map (\(f,_,e) -> fieldname f <> symbol ":" <+> pretty e ) fs)


### PR DESCRIPTION
now it should be able to parse `L (L1 1B) 2B`

---

wip/todo: currently pretty print won't distinguish `(L (2B at 2B)) at 2B` and `L ((2B at 2B) at 2B)`, and `L (2B at 2B) at 2B` will be recognised as the latter, we may force using parens for layout args later.