### PR TITLE
after fields support & constraint-based typechecker for layouts

### DIFF
--- a/cogent/src/Cogent/Dargent/Allocation.hs
+++ b/cogent/src/Cogent/Dargent/Allocation.hs
@@ -38,6 +38,7 @@ module Cogent.Dargent.Allocation
   , (/\)
   , overlaps
   , isZeroSizedAllocation
+  , allocationEnd
   , AlignedBitRange (..)
   , alignSize
   , alignOffsettable
@@ -56,6 +57,7 @@ import GHC.Generics (Generic)
 import Cogent.Common.Types
 import Cogent.Common.Syntax
 import Cogent.Compiler
+import Cogent.Dargent.Surface
 import Cogent.Dargent.Util
 import Cogent.Util
 
@@ -124,25 +126,25 @@ newtype OverlappingAllocationBlocks p =
 -- Represents the set which is the union of the sets represented by the 'BitRange's in the list.
 --
 -- We keep an internal invariant that the list is sorted.
-newtype Allocation' p = Allocation { unAllocation :: [AllocationBlock p] }
+data Allocation' p = Allocation { unAllocation :: [AllocationBlock p], unAllocationUnifier :: Maybe [Int] }
   deriving (Eq, Show, Ord, Functor)
 
 instance Offsettable (Allocation' p) where
-  offset n = Allocation . fmap (first (offset n)) . unAllocation
+  offset n a = flip Allocation (unAllocationUnifier a) $ (fmap (first (offset n)) . unAllocation) a
 
 emptyAllocation :: Allocation' p
-emptyAllocation = Allocation []
+emptyAllocation = Allocation [] Nothing
 
 singletonAllocation :: AllocationBlock p -> Allocation' p
-singletonAllocation b = Allocation [b]
+singletonAllocation b = Allocation [b] Nothing
 
-undeterminedAllocation :: Allocation' p
-undeterminedAllocation = __fixme $ Allocation [] -- FIXME: we may need different rep
+undeterminedAllocation :: Int -> Allocation' p
+undeterminedAllocation n = Allocation [] $ Just [n]
 
 -- | Disjunction of allocations
 --
 (\/) :: forall p. Ord p => Allocation' p -> Allocation' p -> Allocation' p
-(Allocation a1) \/ (Allocation a2) = Allocation (a1 ++ a2)
+(Allocation a1 u1) \/ (Allocation a2 u2) = Allocation (a1 ++ a2) $ (++) <$> u1 <*> u2
 
 
 -- | Conjunction of allocations
@@ -152,10 +154,10 @@ undeterminedAllocation = __fixme $ Allocation [] -- FIXME: we may need different
 -- It will either succeed, with an allocation, or return overlapping allocation blocks
 -- if the two allocations overlap.
 (/\) :: forall p. Ord p => Allocation' p -> Allocation' p -> Either [OverlappingAllocationBlocks p] (Allocation' p)
-(Allocation a1) /\ (Allocation a2) =
+(Allocation a1 u1) /\ (Allocation a2 u2) =
   case allOverlappingBlocks a1 a2 of
     overlappingBlocks@(_ : _) -> Left overlappingBlocks
-    []                        -> return $ Allocation (a1 ++ a2)
+    []                        -> return $ Allocation (a1 ++ a2) ((++) <$> u1 <*> u2)
   where
     allOverlappingBlocks :: [AllocationBlock p] -> [AllocationBlock p] -> [OverlappingAllocationBlocks p]
     allOverlappingBlocks xbs ybs =
@@ -171,7 +173,13 @@ overlaps (BitRange s1 o1) (BitRange s2 o2) =
         (o2 <= o1  ==>  o2 + s2 <= o1)
 
 isZeroSizedAllocation :: Allocation' p -> Bool
-isZeroSizedAllocation = all (isZeroSizedBR . fst) . unAllocation
+isZeroSizedAllocation a = (all (isZeroSizedBR . fst) . unAllocation) a && (isNothing . unAllocationUnifier) a
+  where
+    isNothing Nothing = True
+    isNothing _       = False
+
+allocationEnd :: Allocation' p -> Size
+allocationEnd a = foldr max 0 $ (\b -> bitOffsetBR b + bitSizeBR b) . fst <$> unAllocation a
 
 
 type Allocation = Allocation' DataLayoutPath

--- a/cogent/src/Cogent/Dargent/Desugar.hs
+++ b/cogent/src/Cogent/Dargent/Desugar.hs
@@ -37,6 +37,7 @@ import Cogent.Common.Syntax         ( DataLayoutName
                                     , FieldName
                                     )
 import Cogent.Common.Types          ( Sigil(Unboxed, Boxed), PrimInt(..))
+import Cogent.Core                  ( Type(..) )
 import Cogent.Dargent.Allocation
 import Cogent.Dargent.Core
 import Cogent.Dargent.Surface       ( DataLayoutSize(Bytes, Bits, Add)
@@ -44,8 +45,8 @@ import Cogent.Dargent.Surface       ( DataLayoutSize(Bytes, Bits, Add)
                                     , DataLayoutExpr'(..)
                                     , evalSize
                                     )
+import Cogent.Dargent.TypeCheck     ( TCDataLayout )
 import Cogent.Dargent.Util
-import Cogent.Core                  ( Type(..) )
 
 {- * Helper functions used in Core.Desugar -}
 
@@ -53,12 +54,12 @@ import Cogent.Core                  ( Type(..) )
 --   Primitive types have no sigil, and abstract types may be boxed or unboxed but have no layout.
 --   'desugarAbstractTypeSigil' should only be used when desugaring the sigils of abstract types, to eliminate the @Maybe DataLayoutExpr@.
 desugarAbstractTypeSigil
-  :: Sigil (Maybe DataLayoutExpr)
+  :: Sigil (Maybe TCDataLayout)
   -> Sigil ()
 desugarAbstractTypeSigil = fmap desugarMaybeLayout
   where
     desugarMaybeLayout Nothing = ()
-    desugarMaybeLayout _       = __impossible $ "desugarAbstractTypeSigil (Called on TCon after normalisation, only for case when it is an abstract type)"
+    desugarMaybeLayout _       = __impossible "desugarAbstractTypeSigil (Called on TCon after normalisation, only for case when it is an abstract type)"
 
 desugarSize :: DataLayoutSize -> Size
 desugarSize = evalSize

--- a/cogent/src/Cogent/Dargent/Surface.hs
+++ b/cogent/src/Cogent/Dargent/Surface.hs
@@ -65,6 +65,7 @@ data DataLayoutExpr' e
 #endif
   | Offset  e DataLayoutSize
   | RepRef  RepName [e]
+  | After   e FieldName
   | LVar    DLVarName
   | Ptr
   deriving (Show, Data, Eq, Ord)
@@ -81,6 +82,7 @@ pattern DLArray e s    = DL (Array e s)
 #endif
 pattern DLOffset e s   = DL (Offset e s)
 pattern DLRepRef n s   = DL (RepRef n s)
+pattern DLAfter e f    = DL (After e f)
 pattern DLVar n        = DL (LVar n)
 pattern DLPtr          = DL Ptr
 

--- a/cogent/src/Cogent/Dargent/TypeCheck.hs
+++ b/cogent/src/Cogent/Dargent/TypeCheck.hs
@@ -19,6 +19,7 @@
 
 module Cogent.Dargent.TypeCheck where
 
+import qualified Data.Graph.Wrapper as G
 import Data.Map (Map)
 import qualified Data.Map as M
 import Data.Maybe (fromJust, fromMaybe)
@@ -70,8 +71,8 @@ toDLExpr (TLVariant e fs) = DLVariant (toDLExpr e) ((\(x,y,z,v) -> (x,y,z,toDLEx
 toDLExpr (TLArray e p) = DLArray (toDLExpr e) p
 #endif
 toDLExpr (TLOffset e s) = DLOffset (toDLExpr e) s
+toDLExpr (TLAfter e f)  = DLAfter (toDLExpr e) f
 toDLExpr (TLRepRef n s) = DLRepRef n $ toDLExpr <$> s
-toDLExpr (TLAfter e f)  = flip DLAfter f $ toDLExpr e
 toDLExpr (TLVar n) = DLVar n
 toDLExpr TLPtr = DLPtr
 toDLExpr (TLU _) = __impossible "toDLExpr: layout unifiers shouldn't be here"
@@ -163,6 +164,7 @@ normaliseLayout env (TLRecord fs) = TLRecord $ (\(n, p, l) -> (n, p, normaliseLa
 normaliseLayout env (TLVariant t as) = TLVariant (normaliseLayout env t) $
   (\(n, p, s, l) -> (n, p, s, normaliseLayout env l)) <$> as
 normaliseLayout env (TLOffset l n) = TLOffset (normaliseLayout env l) n
+normaliseLayout env (TLAfter l f) = TLAfter (normaliseLayout env l) f
 #ifdef BUILTIN_ARRAYS
 normaliseLayout env (TLArray l p) = TLArray (normaliseLayout env l) p
 #endif
@@ -179,6 +181,7 @@ substTCDataLayout = f
     f ps (TLRecord fs) = TLRecord $ third3 (f ps) <$> fs
     f ps (TLVariant t fs) = TLVariant (f ps t) $ fourth4 (f ps) <$> fs
     f ps (TLOffset e s) = flip TLOffset s $ f ps e
+    f ps (TLAfter e n) = flip TLAfter n $ f ps e
 #ifdef BUILTIN_ARRAYS
     f ps (TLArray e p) = flip TLArray p $ f ps e
 #endif
@@ -222,6 +225,8 @@ data DataLayoutTcErrorP p
 
   | UnknownDataLayoutVar    DLVarName p
   | DataLayoutArgsNotMatch  DataLayoutName Int Int p
+  | OverlappingFields       [FieldName] p
+  | CyclicFieldDepedency    [FieldName] p
   deriving (Eq, Show, Ord, Functor)
 
 
@@ -263,6 +268,12 @@ unknownDataLayoutVar n = UnknownDataLayoutVar n PathEnd
 
 dataLayoutArgsNotMatch :: DLVarName -> Int -> Int -> DataLayoutTcError
 dataLayoutArgsNotMatch n exp act = DataLayoutArgsNotMatch n exp act PathEnd
+
+overlappingFields :: [FieldName] -> DataLayoutTcError
+overlappingFields fs = OverlappingFields fs PathEnd
+
+cyclicFieldDependency :: G.SCC FieldName -> DataLayoutTcError
+cyclicFieldDependency (G.CyclicSCC fs) = CyclicFieldDepedency fs PathEnd
 
 mapPaths
   :: (DataLayoutPath -> DataLayoutPath)

--- a/cogent/src/Cogent/Dargent/TypeCheck.hs
+++ b/cogent/src/Cogent/Dargent/TypeCheck.hs
@@ -21,7 +21,7 @@ module Cogent.Dargent.TypeCheck where
 
 import Data.Map (Map)
 import qualified Data.Map as M
-import Data.Maybe (fromJust)
+import Data.Maybe (fromJust, fromMaybe)
 
 import Control.Monad (guard, foldM)
 import Control.Monad.Trans.Except
@@ -56,6 +56,7 @@ pattern TLArray e s    = TL (Array e s)
 #endif
 pattern TLOffset e s   = TL (Offset e s)
 pattern TLRepRef n s   = TL (RepRef n s)
+pattern TLAfter e f    = TL (After e f)
 pattern TLVar n        = TL (LVar n)
 pattern TLPtr          = TL Ptr
 
@@ -70,6 +71,7 @@ toDLExpr (TLArray e p) = DLArray (toDLExpr e) p
 #endif
 toDLExpr (TLOffset e s) = DLOffset (toDLExpr e) s
 toDLExpr (TLRepRef n s) = DLRepRef n $ toDLExpr <$> s
+toDLExpr (TLAfter e f)  = flip DLAfter f $ toDLExpr e
 toDLExpr (TLVar n) = DLVar n
 toDLExpr TLPtr = DLPtr
 toDLExpr (TLU _) = __impossible "toDLExpr: layout unifiers shouldn't be here"
@@ -82,205 +84,94 @@ toTCDL (DLVariant e fs) = TLVariant (toTCDL e) ((\(x,y,z,v) -> (x,y,z,toTCDL v))
 toTCDL (DLArray e p) = TLArray (toTCDL e) p
 #endif
 toTCDL (DLOffset e s) = TLOffset (toTCDL e) s
+toTCDL (DLAfter e s) = TLAfter (toTCDL e) s
 toTCDL (DLRepRef n s) = TLRepRef n $ toTCDL <$> s
 toTCDL (DLVar n) = TLVar n
 toTCDL DLPtr = TLPtr
 
-{- * Important exported functions -}
+-- the following code block is for reference only and will be removed later
+{-
+ - tcTCDataLayout :: NamedDataLayouts -> TCDataLayout -> Except [DataLayoutTcError] Allocation
+ - tcTCDataLayout env (TLRepRef n s) =
+ -   case M.lookup n env of
+ -     Just ([], _, Just allocation) | length s > 0 -> throwE [TooManyDataLayoutArgs n PathEnd]
+ -                                   | otherwise    -> mapPaths (InDecl n) $ return allocation
+ -     Just ([], _, Nothing) -> throwE [BadDataLayout n PathEnd]
+ -     Just (vars, expr, _)  | length vars == length s
+ -                           -> tcTCDataLayout env (substTCDataLayout (zip vars s) $ toTCDL expr)
+ -                           | length vars >  length s
+ -                           -> throwE [TooFewDataLayoutArgs n PathEnd]
+ -                           | length vars <  length s
+ -                           -> throwE [TooManyDataLayoutArgs n PathEnd]
+ -     Nothing               -> throwE [UnknownDataLayout n PathEnd]
+ - 
+ - tcTCDataLayout _ (TLPrim size) = return $ singletonAllocation (bitRange, PathEnd)
+ -   where
+ -     bitSize  = evalSize size
+ -     bitRange = fromJust $ newBitRangeBaseSize 0 bitSize {- 0 <= bitSize -}
+ - 
+ - tcTCDataLayout env (TLOffset dataLayout offsetSize) =
+ -   offset (evalSize offsetSize) <$> tcTCDataLayout env dataLayout
+ - 
+ - tcTCDataLayout env (TLRecord fields) = foldM tcField emptyAllocation fields
+ -   where
+ -     tcField accumAlloc (fn, pos, tcl) = do
+ -       fieldsAlloc <- mapPaths (InField fn pos) $ tcTCDataLayout env tcl
+ -       except $ first (fmap OverlappingBlocks) $ accumAlloc /\ fieldsAlloc
+ - 
+ - tcTCDataLayout env (TLVariant tagExpr alternatives) =
+ -   case primitiveBitRange tagExpr of
+ -     Just tagBits | isZeroSizedBR tagBits -> throwE [ZeroSizedBitRange (InTag PathEnd)]
+ -                  | otherwise ->
+ -       do
+ -         altsAlloc <- fst <$> foldM (tcAlternative tagBits) (emptyAllocation, M.empty) alternatives
+ -         except $ first (fmap OverlappingBlocks) $ singletonAllocation (tagBits, InTag PathEnd) /\ altsAlloc
+ -     Nothing      -> throwE [TagNotSingleBlock (InTag PathEnd)]
+ -   where
+ -     tcAlternative range (accumAlloc, accumTagValues) (tagName, pos, tagValue, tcl) = do
+ -       alloc     <- (\/) accumAlloc <$> mapPaths (InAlt tagName pos) (tcTCDataLayout env tcl)
+ -       tagValues <- checkedTagValues
+ -       return (alloc, tagValues)
+ -       where
+ -         checkedTagValues :: Except [DataLayoutTcError] (Map Size TagName)
+ -         checkedTagValues
+ -           | tagValue < 0 || tagValue >= 2 ^ bitSizeBR range =
+ -             throwE [OversizedTagValue (InAlt tagName pos PathEnd) range tagName tagValue]
+ -           | Just conflictingTagName <- tagValue `M.lookup` accumTagValues =
+ -             throwE [SameTagValues (InAlt tagName pos PathEnd) conflictingTagName tagName tagValue]
+ -           | otherwise =
+ -             return $ M.insert tagValue tagName accumTagValues
+ -     primitiveBitRange (TLPrim size)        = newBitRangeBaseSize 0 (evalSize size)
+ -     primitiveBitRange (TLOffset expr size) = offset (evalSize size) <$> primitiveBitRange expr
+ -     primitiveBitRange _                    = Nothing
+ - 
+ - #ifdef BUILTIN_ARRAYS
+ - tcTCDataLayout env (TLArray e p) = mapPaths (InElmt p) $ tcTCDataLayout env e
+ - #endif
+ - tcTCDataLayout _ TLPtr = return $ singletonAllocation (pointerBitRange, PathEnd)
+ - tcTCDataLayout _ (TLU _) = return undeterminedAllocation
+ - tcTCDataLayout _ l = __impossible $ "tcTCDataLayout; tried to typecheck unexpected layout: " ++ show l
+ -}
 
--- | Checks that the layout structure is valid
---
--- This includes that relevant blocks of bits don't overlap
--- And tag values are in the right ranges
-tcDataLayoutExpr :: NamedDataLayouts -> [DLVarName] -> DataLayoutExpr -> Except [DataLayoutTcError] Allocation
-tcDataLayoutExpr env vs (DLRepRef n s) =
+-- | Replaces refs with concrete layout expression
+normaliseLayout :: NamedDataLayouts -> TCDataLayout -> TCDataLayout
+normaliseLayout env (TLRepRef n s) =
   case M.lookup n env of
-    Just ([], _, Just allocation) | length s > 0 -> throwE [TooManyDataLayoutArgs n PathEnd]
-                                  | otherwise    -> mapPaths (InDecl n) $ return allocation
-    Just ([], _, Nothing) -> throwE [BadDataLayout n PathEnd]
-    Just (vars, expr, _)  | length s == length vars
-                          -> tcDataLayoutExpr env vs (substDataLayoutExpr (zip vars s) expr)
-                          | length s <  length vars
-                          -> throwE [TooFewDataLayoutArgs n PathEnd]
-                          | length s >  length vars
-                          -> throwE [TooManyDataLayoutArgs n PathEnd]
-    Nothing               -> throwE [UnknownDataLayout n PathEnd]
-
-tcDataLayoutExpr _ _ (DLPrim size) = return $ singletonAllocation (bitRange, PathEnd)
-  where
-    bitSize  = evalSize size
-    bitRange = fromJust $ newBitRangeBaseSize 0 bitSize {- 0 <= bitSize -}
-
-tcDataLayoutExpr env vs (DLOffset dataLayoutExpr offsetSize) =
-  offset (evalSize offsetSize) <$> tcDataLayoutExpr env vs dataLayoutExpr
-
-tcDataLayoutExpr env vs (DLRecord fields) = foldM tcField emptyAllocation fields
-  where
-    tcField
-      :: Allocation -- The accumulated allocation from previous alternatives
-      -> (FieldName, SourcePos, DataLayoutExpr)
-      -> Except [DataLayoutTcError] Allocation
-
-    tcField accumAlloc (fieldName, pos, dataLayoutExpr) = do
-      fieldsAlloc <- mapPaths (InField fieldName pos) (tcDataLayoutExpr env vs dataLayoutExpr)
-      except $ first (fmap OverlappingBlocks) $ accumAlloc /\ fieldsAlloc
-
-tcDataLayoutExpr env vs (DLVariant tagExpr alternatives) =
-  case primitiveBitRange tagExpr of
-    Just tagBits | isZeroSizedBR tagBits -> throwE [ZeroSizedBitRange (InTag PathEnd)]
-                 | otherwise ->
-      do
-        altsAlloc <- fst <$> foldM (tcAlternative tagBits) (emptyAllocation, M.empty) alternatives
-        except $ first (fmap OverlappingBlocks) $ singletonAllocation (tagBits, InTag PathEnd) /\ altsAlloc
-    Nothing      -> throwE [TagNotSingleBlock (InTag PathEnd)]
-  where
-    tcAlternative
-      :: BitRange -- Of the variant's tag
-      -> (Allocation, Map Size TagName)  -- The accumulated (allocation, set of used tag values) from already evaluated alternatives
-      -> (TagName, SourcePos, Size, DataLayoutExpr) -- The alternative to evaluate
-      -> Except [DataLayoutTcError] (Allocation, Map Size TagName)
-
-    tcAlternative range (accumAlloc, accumTagValues) (tagName, pos, tagValue, dataLayoutExpr) = do
-      alloc     <- (\/) accumAlloc <$> mapPaths (InAlt tagName pos) (tcDataLayoutExpr env vs dataLayoutExpr)
-      tagValues <- checkedTagValues
-      return (alloc, tagValues)
-      where
-        checkedTagValues :: Except [DataLayoutTcError] (Map Size TagName)
-        checkedTagValues
-          | tagValue < 0 || tagValue >= 2 ^ bitSizeBR range =
-            throwE [OversizedTagValue (InAlt tagName pos PathEnd) range tagName tagValue]
-          | Just conflictingTagName <- tagValue `M.lookup` accumTagValues =
-            throwE [SameTagValues (InAlt tagName pos PathEnd) conflictingTagName tagName tagValue]
-          | otherwise =
-            return $ M.insert tagValue tagName accumTagValues
-
-    primitiveBitRange :: DataLayoutExpr -> Maybe BitRange
-    primitiveBitRange (DLPrim size)        = newBitRangeBaseSize 0 (evalSize size)
-    primitiveBitRange (DLOffset expr size) = offset (evalSize size) <$> primitiveBitRange expr
-    primitiveBitRange _                    = Nothing
-
+    Just (vars, expr) -> normaliseLayout env (substTCDataLayout (zip vars s) expr)
+    Nothing -> __impossible $ "normaliseLayout (RepRef " ++ show n ++ " already known to exist)"
+normaliseLayout env (TLRecord fs) = TLRecord $ (\(n, p, l) -> (n, p, normaliseLayout env l)) <$> fs
+normaliseLayout env (TLVariant t as) = TLVariant (normaliseLayout env t) $
+  (\(n, p, s, l) -> (n, p, s, normaliseLayout env l)) <$> as
+normaliseLayout env (TLOffset l n) = TLOffset (normaliseLayout env l) n
 #ifdef BUILTIN_ARRAYS
-tcDataLayoutExpr env vs (DLArray e p) = mapPaths (InElmt p) $ tcDataLayoutExpr env vs e
+normaliseLayout env (TLArray l p) = TLArray (normaliseLayout env l) p
 #endif
-tcDataLayoutExpr _ _ DLPtr = return $ singletonAllocation (pointerBitRange, PathEnd)
-tcDataLayoutExpr _ vs (DLVar n) = if n `elem` vs then return undeterminedAllocation
-                                                 else throwE [UnknownDataLayoutVar n PathEnd]
-tcDataLayoutExpr _ _ l = __impossible $ "tcDataLayoutExpr; tried to typecheck unexpected layout: " ++ show l
-
-
--- | Check the layout after subsitution within constraint generator for TLApp
--- We may simplify this function or refactor the layout related constraints later
-tcTCDataLayout :: NamedDataLayouts -> TCDataLayout -> Except [DataLayoutTcError] Allocation
-tcTCDataLayout env (TLRepRef n s) =
-  case M.lookup n env of
-    Just ([], _, Just allocation) | length s > 0 -> throwE [TooManyDataLayoutArgs n PathEnd]
-                                  | otherwise    -> mapPaths (InDecl n) $ return allocation
-    Just ([], _, Nothing) -> throwE [BadDataLayout n PathEnd]
-    Just (vars, expr, _)  | length vars == length s
-                          -> tcTCDataLayout env (substTCDataLayout (zip vars s) $ toTCDL expr)
-                          | length vars >  length s
-                          -> throwE [TooFewDataLayoutArgs n PathEnd]
-                          | length vars <  length s
-                          -> throwE [TooManyDataLayoutArgs n PathEnd]
-    Nothing               -> throwE [UnknownDataLayout n PathEnd]
-
-tcTCDataLayout _ (TLPrim size) = return $ singletonAllocation (bitRange, PathEnd)
-  where
-    bitSize  = evalSize size
-    bitRange = fromJust $ newBitRangeBaseSize 0 bitSize {- 0 <= bitSize -}
-
-tcTCDataLayout env (TLOffset dataLayout offsetSize) =
-  offset (evalSize offsetSize) <$> tcTCDataLayout env dataLayout
-
-tcTCDataLayout env (TLRecord fields) = foldM tcField emptyAllocation fields
-  where
-    tcField accumAlloc (fn, pos, tcl) = do
-      fieldsAlloc <- mapPaths (InField fn pos) $ tcTCDataLayout env tcl
-      except $ first (fmap OverlappingBlocks) $ accumAlloc /\ fieldsAlloc
-
-tcTCDataLayout env (TLVariant tagExpr alternatives) =
-  case primitiveBitRange tagExpr of
-    Just tagBits | isZeroSizedBR tagBits -> throwE [ZeroSizedBitRange (InTag PathEnd)]
-                 | otherwise ->
-      do
-        altsAlloc <- fst <$> foldM (tcAlternative tagBits) (emptyAllocation, M.empty) alternatives
-        except $ first (fmap OverlappingBlocks) $ singletonAllocation (tagBits, InTag PathEnd) /\ altsAlloc
-    Nothing      -> throwE [TagNotSingleBlock (InTag PathEnd)]
-  where
-    tcAlternative range (accumAlloc, accumTagValues) (tagName, pos, tagValue, tcl) = do
-      alloc     <- (\/) accumAlloc <$> mapPaths (InAlt tagName pos) (tcTCDataLayout env tcl)
-      tagValues <- checkedTagValues
-      return (alloc, tagValues)
-      where
-        checkedTagValues :: Except [DataLayoutTcError] (Map Size TagName)
-        checkedTagValues
-          | tagValue < 0 || tagValue >= 2 ^ bitSizeBR range =
-            throwE [OversizedTagValue (InAlt tagName pos PathEnd) range tagName tagValue]
-          | Just conflictingTagName <- tagValue `M.lookup` accumTagValues =
-            throwE [SameTagValues (InAlt tagName pos PathEnd) conflictingTagName tagName tagValue]
-          | otherwise =
-            return $ M.insert tagValue tagName accumTagValues
-    primitiveBitRange (TLPrim size)        = newBitRangeBaseSize 0 (evalSize size)
-    primitiveBitRange (TLOffset expr size) = offset (evalSize size) <$> primitiveBitRange expr
-    primitiveBitRange _                    = Nothing
-
-#ifdef BUILTIN_ARRAYS
-tcTCDataLayout env (TLArray e p) = mapPaths (InElmt p) $ tcTCDataLayout env e
-#endif
-tcTCDataLayout _ TLPtr = return $ singletonAllocation (pointerBitRange, PathEnd)
-tcTCDataLayout _ (TLU _) = return undeterminedAllocation
-tcTCDataLayout _ l = __impossible $ "tcTCDataLayout; tried to typecheck unexpected layout: " ++ show l
-
-
--- NOTE: the check for type-layout compatibility is in Cogent.TypeCheck.Base
-
--- | Normalises the layout remove references to named layouts
-normaliseDataLayoutExpr :: NamedDataLayouts -> DataLayoutExpr -> DataLayoutExpr
-normaliseDataLayoutExpr env (DLRepRef n s) =
-  case M.lookup n env of
-    Just (vars, expr, _) -> normaliseDataLayoutExpr env (substDataLayoutExpr (zip vars s) expr)
-    Nothing -> __impossible $ "normaliseDataLayoutExpr (RepRef " ++ show n ++ " already known to exist)"
-normaliseDataLayoutExpr env (DLRecord fields) =
-  DLRecord (fmap (\(fn, pos, expr) -> (fn, pos, normaliseDataLayoutExpr env expr)) fields)
-normaliseDataLayoutExpr env (DLVariant tag alts) =
-  DLVariant (normaliseDataLayoutExpr env tag) $
-    fmap (\(tn, pos, size, expr) -> (tn, pos, size, normaliseDataLayoutExpr env expr)) alts
-normaliseDataLayoutExpr env (DLOffset expr size) = DLOffset (normaliseDataLayoutExpr env expr) size
-#ifdef BUILTIN_ARRAYS
-normaliseDataLayoutExpr env (DLArray e pos) = DLArray (normaliseDataLayoutExpr env e) pos
-#endif
-normaliseDataLayoutExpr _ r = r
-
-normaliseTCDataLayout :: NamedDataLayouts -> TCDataLayout -> TCDataLayout
-normaliseTCDataLayout env (TLRepRef n s) =
-  case M.lookup n env of
-    Just (vars, expr, _) -> let s' = toDLExpr <$> s
-                             in toTCDL $ normaliseDataLayoutExpr env (substDataLayoutExpr (zip vars s') expr)
-    Nothing -> __impossible $ "normaliseTCDataLayout (RepRef " ++ show n ++ " already known to exist)"
-normaliseTCDataLayout env (TLRecord fs) = TLRecord $ (\(n, p, l) -> (n, p, normaliseTCDataLayout env l)) <$> fs
-normaliseTCDataLayout env (TLVariant t as) = TLVariant t $ (\(n, p, s, l) -> (n, p, s, normaliseTCDataLayout env l)) <$> as
-normaliseTCDataLayout env (TLOffset l n) = TLOffset (normaliseTCDataLayout env l) n
-#ifdef BUILTIN_ARRAYS
-normaliseTCDataLayout env (TLArray l p) = TLArray (normaliseTCDataLayout env l) p
-#endif
-normaliseTCDataLayout _ l = l
+normaliseLayout _ (TLPrim n) = TLPrim n
+normaliseLayout _ (TLVar n) = TLVar n
+normaliseLayout _ TLPtr = TLPtr
+normaliseLayout _ l = __impossible $ "normaliseLayout: unexpeced layout " ++ show l
 
 -- | Substitutes layout variables with concrete layouts
-substDataLayoutExpr :: [(DLVarName, DataLayoutExpr)] -> DataLayoutExpr -> DataLayoutExpr
-substDataLayoutExpr = f
-  where
-    f ps (DLRepRef n s) = DLRepRef n $ f ps <$> s
-    f ps (DLRecord fs) = DLRecord $ third3 (f ps) <$> fs
-    f ps (DLVariant t fs) = DLVariant (f ps t) $ fourth4 (f ps) <$> fs
-    f ps (DLOffset e s) = flip DLOffset s $ f ps e
-#ifdef BUILTIN_ARRAYS
-    f ps (DLArray e p) = flip DLArray p $ f ps e
-#endif
-    f ps (DLVar n) = case lookup n ps of
-                       Just v -> v
-                       Nothing -> DLVar n
-    f ps e = e
-
 substTCDataLayout :: [(DLVarName, TCDataLayout)] -> TCDataLayout -> TCDataLayout
 substTCDataLayout = f
   where
@@ -291,14 +182,12 @@ substTCDataLayout = f
 #ifdef BUILTIN_ARRAYS
     f ps (TLArray e p) = flip TLArray p $ f ps e
 #endif
-    f ps (TLVar n) = case lookup n ps of
-                       Just v -> v
-                       Nothing -> TLVar n
+    f ps (TLVar n) = fromMaybe (TLVar n) (lookup n ps)
     f ps e = e
 
 {- * Types -}
--- TODO: we may change DataLayoutExpr within NamedDataLayouts
-type NamedDataLayouts = Map DataLayoutName ([DLVarName], DataLayoutExpr, Maybe Allocation)
+type DataLayoutEnv e = Map DataLayoutName ([DLVarName], e)
+type NamedDataLayouts = DataLayoutEnv TCDataLayout
 type DataLayoutTcError = DataLayoutTcErrorP DataLayoutPath
 -- type DataLayoutTypeMatchError = DataLayoutTcErrorP DataLayoutPath -- TODO: needed to implement `tcDataLayoutTypeMatch`
 
@@ -332,8 +221,7 @@ data DataLayoutTcErrorP p
   -- This could generate an array of length 0, which is disallowed by C
 
   | UnknownDataLayoutVar    DLVarName p
-  | TooFewDataLayoutArgs    DataLayoutName p
-  | TooManyDataLayoutArgs   DataLayoutName p
+  | DataLayoutArgsNotMatch  DataLayoutName Int Int p
   deriving (Eq, Show, Ord, Functor)
 
 
@@ -362,17 +250,19 @@ data DataLayoutTypeMatchErrorP p
 
 
 {- * Other exported functions -}
-tcDataLayoutDecl :: NamedDataLayouts -> DataLayoutDecl -> Except [DataLayoutTcError] Allocation
-tcDataLayoutDecl env (DataLayoutDecl pos name vars expr) =
-  mapPaths (InDecl name) (tcDataLayoutExpr env vars expr)
-
-normaliseDataLayoutDecl :: NamedDataLayouts -> DataLayoutDecl -> DataLayoutDecl
-normaliseDataLayoutDecl env (DataLayoutDecl pos name vars expr) =
-  DataLayoutDecl pos name vars (normaliseDataLayoutExpr env expr)
 
 -- Normalises the layout in the sigil to remove references to named layouts
 normaliseSigil :: NamedDataLayouts -> Sigil (Maybe TCDataLayout) -> Sigil (Maybe TCDataLayout)
-normaliseSigil env = fmap (fmap (normaliseTCDataLayout env))
+normaliseSigil env = fmap (fmap (normaliseLayout env))
+
+unknownDataLayout :: DataLayoutName -> DataLayoutTcError
+unknownDataLayout n = UnknownDataLayout n PathEnd
+
+unknownDataLayoutVar :: DLVarName -> DataLayoutTcError
+unknownDataLayoutVar n = UnknownDataLayoutVar n PathEnd
+
+dataLayoutArgsNotMatch :: DLVarName -> Int -> Int -> DataLayoutTcError
+dataLayoutArgsNotMatch n exp act = DataLayoutArgsNotMatch n exp act PathEnd
 
 mapPaths
   :: (DataLayoutPath -> DataLayoutPath)

--- a/cogent/src/Cogent/Desugar.hs
+++ b/cogent/src/Cogent/Desugar.hs
@@ -604,7 +604,7 @@ desugarType = \case
     -- NOTE: if the user specify boxed array containing boxed types with layout defined as pointer,
     --       we simply turn that into CLayout to avoid generating extra getters & setters
     ds <- case sigil of
-            Boxed ro (Just (S.DLArray S.DLPtr _)) -> pure $ Boxed ro CLayout
+            Boxed ro (Just (TLArray TLPtr _)) -> pure $ Boxed ro CLayout
             _ -> desugarSigil sigil
     TArray <$> pure t'
            <*> pure l'
@@ -627,17 +627,18 @@ desugarLayout l = Layout <$> desugarLayout' l
       TLOffset e n -> do
         e' <- desugarLayout' e
         pure $ offset (DD.desugarSize n) e'
+      TLAfter e f -> __impossible "desugarLayout: TLAfter should already be normalised before"
       TLRecord fs -> do
-        let f (n,_,l) = desugarLayout' l >>= pure . (n,)
+        let f (n,_,l) = (n,) <$> desugarLayout' l
         fs' <- mapM f fs
         pure $ RecordLayout (M.fromList fs')
       TLVariant te alts -> do
         te' <- desugarLayout' te
         let tr = case te' of
                    PrimLayout range -> range
-                   UnitLayout       -> __impossible $ "desugarLayout: zero sized bit range for variant tag"
-                   _                -> __impossible $ "desugarLayout: tag layout known to be a single range"
-        let f (n,_,s,l) = desugarLayout' l >>= pure . (n,) . (s,)
+                   UnitLayout       -> __impossible "desugarLayout: zero sized bit range for variant tag"
+                   _                -> __impossible "desugarLayout: tag layout known to be a single range"
+        let f (n,_,s,l) = (n,) . (s,) <$> desugarLayout' l
         alts' <- mapM f alts
         pure $ SumLayout tr (M.fromList alts')
       TLPtr -> pure $ PrimLayout DA.pointerBitRange
@@ -648,9 +649,9 @@ desugarLayout l = Layout <$> desugarLayout' l
         Just v -> pure $ VarLayout (finNat v)
         Nothing -> __impossible "desugarLayout: unexpected layout variable - check typecheck"
 
-desugarSigil :: Sigil (Maybe DataLayoutExpr) -> DS t l v (Sigil (DataLayout DA.BitRange))
+desugarSigil :: Sigil (Maybe TCDataLayout) -> DS t l v (Sigil (DataLayout DA.BitRange))
 desugarSigil (Boxed b Nothing)  = pure $ Boxed b CLayout
-desugarSigil (Boxed b (Just l)) = Boxed b <$> desugarLayout (toTCDL l)
+desugarSigil (Boxed b (Just l)) = Boxed b <$> desugarLayout l
 desugarSigil Unboxed            = pure Unboxed
 
 desugarNote :: S.Inline -> FunNote

--- a/cogent/src/Cogent/Desugar.hs
+++ b/cogent/src/Cogent/Desugar.hs
@@ -627,7 +627,7 @@ desugarLayout l = Layout <$> desugarLayout' l
       TLOffset e n -> do
         e' <- desugarLayout' e
         pure $ offset (DD.desugarSize n) e'
-      TLAfter e f -> __impossible "desugarLayout: TLAfter should already be normalised before"
+      TLAfter e f -> __todo "code gen schedule for \"after\" fields"
       TLRecord fs -> do
         let f (n,_,l) = (n,) <$> desugarLayout' l
         fs' <- mapM f fs

--- a/cogent/src/Cogent/Desugar.hs
+++ b/cogent/src/Cogent/Desugar.hs
@@ -627,9 +627,12 @@ desugarLayout l = Layout <$> desugarLayout' l
       TLOffset e n -> do
         e' <- desugarLayout' e
         pure $ offset (DD.desugarSize n) e'
-      TLAfter e f -> __todo "code gen schedule for \"after\" fields"
+      TLAfter e f -> __impossible "desugarLayout: TLAfter should be desugared at its parent level"
       TLRecord fs -> do
-        let f (n,_,l) = (n,) <$> desugarLayout' l
+        let fieldEnd' = fieldEnd $ (\(a,_,c) -> (a,c)) <$> fs
+        let f (n,_,l) = case l of
+                          TLAfter e f -> (n,) <$> (offset <$> fieldEnd' f <*> desugarLayout' e)
+                          l -> (n,) <$> desugarLayout' l
         fs' <- mapM f fs
         pure $ RecordLayout (M.fromList fs')
       TLVariant te alts -> do
@@ -638,7 +641,10 @@ desugarLayout l = Layout <$> desugarLayout' l
                    PrimLayout range -> range
                    UnitLayout       -> __impossible "desugarLayout: zero sized bit range for variant tag"
                    _                -> __impossible "desugarLayout: tag layout known to be a single range"
-        let f (n,_,s,l) = (n,) . (s,) <$> desugarLayout' l
+        let fieldEnd' = fieldEnd $ (\(a,_,_,d) -> (a,d)) <$> alts
+        let f (n,_,s,l) = case l of
+                            TLAfter e f -> (n,) . (s,) <$> (offset <$> fieldEnd' f <*> desugarLayout' e)
+                            l -> (n,) . (s,) <$> desugarLayout' l
         alts' <- mapM f alts
         pure $ SumLayout tr (M.fromList alts')
       TLPtr -> pure $ PrimLayout DA.pointerBitRange
@@ -648,6 +654,13 @@ desugarLayout l = Layout <$> desugarLayout' l
       TLVar n -> (findIx n <$> use layCtx) >>= \case
         Just v -> pure $ VarLayout (finNat v)
         Nothing -> __impossible "desugarLayout: unexpected layout variable - check typecheck"
+    fieldEnd :: [(FieldName, TCDataLayout)] -> FieldName -> DS t l v Size
+    fieldEnd t f = case fromJust $ lookup f t of
+      TLAfter e f' -> do
+        be <- fieldEnd t f'
+        fe <- endAllocatedBits' <$> desugarLayout' e
+        return $ be + fe
+      e -> endAllocatedBits' <$> desugarLayout' e
 
 desugarSigil :: Sigil (Maybe TCDataLayout) -> DS t l v (Sigil (DataLayout DA.BitRange))
 desugarSigil (Boxed b Nothing)  = pure $ Boxed b CLayout

--- a/cogent/src/Cogent/PrettyPrint.hs
+++ b/cogent/src/Cogent/PrettyPrint.hs
@@ -684,6 +684,7 @@ instance Pretty d => Pretty (DataLayoutExpr' d) where
   pretty (RepRef n s) = if null s then reprname n else parens $ reprname n <+> hsep (fmap pretty s)
   pretty (Prim sz) = pretty sz
   pretty (Offset e s) = pretty e <+> keyword "at" <+> pretty s
+  pretty (After e f) = pretty e <+> keyword "after" <+> pretty f
   pretty (Record fs) = keyword "record" <+> record (map (\(f,_,e) -> fieldname f <> symbol ":" <+> pretty e ) fs)
   pretty (Variant e vs) = keyword "variant" <+> parens (pretty e)
                                                  <+> record (map (\(f,_,i,e) -> tagname f <+> tupled [literal $ string $ show i] <> symbol ":" <+> pretty e) vs)
@@ -884,6 +885,7 @@ instance Pretty Constraint where
   pretty (l :~ n)         = pretty l </> warn ":~" </> pretty n
   pretty (l :~< m)        = pretty l </> warn ":~<" </> pretty m
   pretty (a :~~ b)        = pretty a </> warn ":~~" </> pretty b
+  pretty (Wellformed l)   = warn "Wellformed" <+> pretty l
 
 -- a more verbose version of constraint pretty-printer which is mostly used for debugging
 prettyC :: Constraint -> Doc
@@ -903,6 +905,7 @@ prettyCPrec l x | prec x < l = prettyC x
 instance Pretty SourceObject where
   pretty (TypeName n) = typename n
   pretty (ValName  n) = varname n
+  pretty (RepName  n) = reprname n
   pretty (DocBlock' _) = __fixme empty  -- FIXME: not implemented
 
 instance Pretty ReorganizeError where
@@ -989,10 +992,10 @@ instance Pretty DataLayoutTcError where
     indent (pretty context)
   pretty (UnknownDataLayoutVar n ctx) =
     err "Undeclared data layout variable" <+> dlvarname n <$$> indent (pretty ctx)
-  pretty (TooFewDataLayoutArgs n ctx) =
-    err "Too few arguments data layout synonym" <+> reprname n <$$> indent (pretty ctx)
-  pretty (TooManyDataLayoutArgs n ctx) =
-    err "Too many arguments for data layout synonym" <+> reprname n <$$> indent (pretty ctx)
+  pretty (DataLayoutArgsNotMatch n exp act ctx) =
+    err "Number of arguments for data layout synonym" <+> reprname n <+> err "not matched,"
+    </> err "expected" <+> int exp <+> err "args, but actual" <+> int act <+> err "args"
+    <$$> indent (pretty ctx)
 
 instance Pretty DataLayoutPath where
   pretty (InField n po ctx) = context' "for field" <+> fieldname n <+> context' "(" <> pretty po <> context' ")" </> pretty ctx

--- a/cogent/src/Cogent/PrettyPrint.hs
+++ b/cogent/src/Cogent/PrettyPrint.hs
@@ -885,7 +885,7 @@ instance Pretty Constraint where
   pretty (l :~ n)         = pretty l </> warn ":~" </> pretty n
   pretty (l :~< m)        = pretty l </> warn ":~<" </> pretty m
   pretty (a :~~ b)        = pretty a </> warn ":~~" </> pretty b
-  pretty (Wellformed l)   = warn "Wellformed" <+> pretty l
+  pretty (WellformedLayout l) = warn "WellformedLayout" <+> pretty l
 
 -- a more verbose version of constraint pretty-printer which is mostly used for debugging
 prettyC :: Constraint -> Doc
@@ -996,6 +996,10 @@ instance Pretty DataLayoutTcError where
     err "Number of arguments for data layout synonym" <+> reprname n <+> err "not matched,"
     </> err "expected" <+> int exp <+> err "args, but actual" <+> int act <+> err "args"
     <$$> indent (pretty ctx)
+  pretty (OverlappingFields fs ctx) =
+    err "Overlapping fields" <+> foldr1 (<+>) (fmap fieldname fs) <$$> indent (pretty ctx)
+  pretty (CyclicFieldDepedency fs ctx) =
+    err "Cyclic dependency of fields" <+> foldr1 (<+>) (fmap fieldname fs) <$$> indent (pretty ctx)
 
 instance Pretty DataLayoutPath where
   pretty (InField n po ctx) = context' "for field" <+> fieldname n <+> context' "(" <> pretty po <> context' ")" </> pretty ctx

--- a/cogent/src/Cogent/PrettyPrint.hs
+++ b/cogent/src/Cogent/PrettyPrint.hs
@@ -1000,6 +1000,8 @@ instance Pretty DataLayoutTcError where
     err "Overlapping fields" <+> foldr1 (<+>) (fmap fieldname fs) <$$> indent (pretty ctx)
   pretty (CyclicFieldDepedency fs ctx) =
     err "Cyclic dependency of fields" <+> foldr1 (<+>) (fmap fieldname fs) <$$> indent (pretty ctx)
+  pretty (NonExistingFields fs ctx) =
+    err "Non-existing fields" <+> foldr1 (<+>) (fmap fieldname fs) <$$> indent (pretty ctx)
 
 instance Pretty DataLayoutPath where
   pretty (InField n po ctx) = context' "for field" <+> fieldname n <+> context' "(" <> pretty po <> context' ")" </> pretty ctx

--- a/cogent/src/Cogent/Surface.hs
+++ b/cogent/src/Cogent/Surface.hs
@@ -599,6 +599,7 @@ lvT (RT _) = []
 lvL :: DataLayoutExpr -> [DLVarName]
 lvL (DLVar n) = [n]
 lvL (DLOffset e _) = lvL e
+lvL (DLAfter e _) = lvL e
 lvL (DLRecord fs) = foldMap (\(_, _, x) -> lvL x) fs
 lvL (DLVariant t alt) = lvL t <> foldMap (\(_, _, _, x) -> lvL x) alt
 #ifdef BUILTIN_ARRAYS
@@ -636,8 +637,8 @@ allRepRefs (DL d) = allRepRefs' d
     allRepRefs' (Array e _) = allRepRefs e
 #endif
     allRepRefs' (Offset e _) = allRepRefs e
-    allRepRefs' (RepRef n s) = [n] ++ concatMap allRepRefs s
     allRepRefs' (After e _) = allRepRefs e
+    allRepRefs' (RepRef n s) = n : concatMap allRepRefs s
     allRepRefs' (LVar _) = []
     allRepRefs' Ptr = []
 

--- a/cogent/src/Cogent/Surface.hs
+++ b/cogent/src/Cogent/Surface.hs
@@ -637,6 +637,7 @@ allRepRefs (DL d) = allRepRefs' d
 #endif
     allRepRefs' (Offset e _) = allRepRefs e
     allRepRefs' (RepRef n s) = [n] ++ concatMap allRepRefs s
+    allRepRefs' (After e _) = allRepRefs e
     allRepRefs' (LVar _) = []
     allRepRefs' Ptr = []
 

--- a/cogent/src/Cogent/TypeCheck.hs
+++ b/cogent/src/Cogent/TypeCheck.hs
@@ -31,9 +31,9 @@ import Cogent.Surface
 import Cogent.TypeCheck.Base
 import Cogent.TypeCheck.Errors
 import Cogent.TypeCheck.Generator
-import Cogent.TypeCheck.Post (postT, postE, postA)
+import Cogent.TypeCheck.Post (postT, postE, postA, postL)
 import Cogent.TypeCheck.Solver
-import Cogent.TypeCheck.Subst (apply, applyE, applyAlts)
+import Cogent.TypeCheck.Subst (apply, applyE, applyL, applyAlts)
 import Cogent.TypeCheck.Util
 import Cogent.Util (firstM, secondM)
 
@@ -67,6 +67,7 @@ typecheck :: [(SourcePos, TopLevel LocType LocPatn LocExpr)]
 typecheck = mapM (uncurry checkOne)
 
 -- TODO: Check for prior definition
+-- NOTE: we may make a choice between VariableNotDeclared and UnknownVariable
 checkOne :: SourcePos -> TopLevel LocType LocPatn LocExpr
          -> TcM (TopLevel DepType TypedPatn TypedExpr)
 checkOne loc d = lift (errCtx .= [InDefinition loc d]) >> case d of
@@ -157,15 +158,25 @@ checkOne loc d = lift (errCtx .= [InDefinition loc d]) >> case d of
 
   (RepDef decl@(DataLayoutDecl pos name vars expr)) -> do
     traceTc "tc" (text "typecheck rep decl" <+> pretty name)
-    namedLayouts            <- lift . lift $ use knownDataLayouts
-    allocation <- case runExcept $ tcDataLayoutDecl namedLayouts decl of
-                    Left es     -> (logErr . DataLayoutError . head $ es) >> return Nothing
-                    Right alloc -> return $ Just alloc
-    -- We add the decl to the knownDataLayouts regarldess of error, so we can continue
-    -- typechecking DataLayoutExprs which might contain the decl.
-    lift . lift $ knownDataLayouts %= M.insert name (vars, expr, allocation)
-    let decl' = normaliseDataLayoutDecl namedLayouts decl
-    return $ RepDef decl'
+    let xs = vars \\ nub vars
+    unless (null xs) $ logErrExit $ DuplicateLayoutVariable xs
+    let elvs = nub (lvL expr)
+        ys = vars \\ elvs
+    unless (null ys) $ logErrExit $ SuperfluousLayoutVariable ys
+    base <- lift . lift $ use knownConsts
+    let ctx = C.addScope (fmap (\(t,_,p) -> (t, p, Seq.singleton p)) base) C.empty
+    let ?loc = loc
+    -- currently no recursive data layout
+    ((c,l), flx, os) <- runCG ctx [] vars (validateLayout expr)
+    traceTc "tc" (text "constraint for rep decl" <+> pretty name <+> text "is"
+                  L.<$> prettyC c)
+    (gs, subst) <- runSolver (solve [] [] c) flx
+    traceTc "tc" (text "substs for rep decl" <+> pretty name <+> text "is"
+                  L.<$> pretty subst)
+    exitOnErr $ toErrors os gs
+    lift . lift $ knownDataLayouts %= M.insert name (vars, l)
+    l' <- postL $ applyL subst l
+    return $ RepDef (DataLayoutDecl pos name vars l')
 
   (ConstDef n (stripLocT -> t) e) -> do
     traceTc "tc" $ bold (text $ replicate 80 '=')

--- a/cogent/src/Cogent/TypeCheck/Base.hs
+++ b/cogent/src/Cogent/TypeCheck/Base.hs
@@ -753,6 +753,7 @@ unifVars (A t l s tkns) = unifVars t ++ rights [s] ++ rights [tkns]
 unifVars (T x) = foldMap unifVars x
 
 unifLVars :: TCDataLayout -> [Int]
+unifLVars (TLU n) = [n]
 unifLVars (TLRecord ps) = concatMap unifLVars (thd3 <$> ps)
 unifLVars (TLVariant t ps) = unifLVars t <> concatMap unifLVars ((\(_,_,_,a) -> a) <$> ps)
 #ifdef BUILTIN_ARRAYS

--- a/cogent/src/Cogent/TypeCheck/Base.hs
+++ b/cogent/src/Cogent/TypeCheck/Base.hs
@@ -95,6 +95,7 @@ data TypeError = FunctionNotFound VarName
                | DuplicateLayoutVariable [DLVarName]
                | SuperfluousLayoutVariable [DLVarName]
                | TypeVariableNotDeclared [TyVarName]
+               | LayoutVariableNotDeclared [DLVarName]
                | TakeFromNonRecordOrVariant (Maybe [FieldName]) TCType
                | PutToNonRecordOrVariant    (Maybe [FieldName]) TCType
                | TakeNonExistingField FieldName TCType
@@ -192,6 +193,7 @@ data Constraint' t l = (:<) t t
                      | (:~) l t
                      | (:~<) l l
                      | (:~~) t t
+                     | Wellformed l  -- TODO local env
                      | (:@) (Constraint' t l) ErrorContext
                      | Unsat TypeError
                      | SemiSat TypeWarning
@@ -273,6 +275,7 @@ instance Bifunctor Constraint' where
   bimap f g (l  :~  t)         = (g l) :~ (f t)
   bimap f g (l1 :~< l2)        = (g l1) :~< (g l2)
   bimap f g (t1 :~~ t2)        = (f t1) :~~ (f t2)
+  bimap f g (Wellformed l)     = Wellformed (g l)
   bimap f g (c  :@  e)         = (bimap f g c) :@ e
   bimap f g (Exhaustive t ps)  = Exhaustive (f t) ps
   bimap f g (Solved t)         = Solved (f t)
@@ -299,6 +302,7 @@ instance Bitraversable Constraint' where
   bitraverse f g (l  :~  t)         = (:~)  <$> g l <*> f t
   bitraverse f g (l1 :~< l2)        = (:~<) <$> g l1 <*> g l2
   bitraverse f g (t1 :~~ t2)        = (:~~) <$> f t1 <*> f t2
+  bitraverse f g (Wellformed l)     = Wellformed <$> g l
   bitraverse f g (c  :@  e)         = (:@)  <$> bitraverse f g c <*> pure e
   bitraverse f g (Exhaustive t ps)  = Exhaustive <$> f t <*> pure ps
   bitraverse f g (Solved t)         = Solved <$> f t
@@ -463,8 +467,7 @@ type TCExpr = TExpr TCType
 type TCPatn = TPatn TCType
 type TCIrrefPatn = TIrrefPatn TCType
 
--- TODO: change DataLayoutExpr into TCDataLayout
-data DepType = DT { unDT :: Type RawTypedExpr DataLayoutExpr DepType } deriving (Data, Eq, Ord, Show)
+data DepType = DT { unDT :: Type RawTypedExpr TCDataLayout DepType } deriving (Data, Eq, Ord, Show)
 
 type TypedName = (VarName, DepType)
 type TypedExpr = TExpr DepType
@@ -503,7 +506,7 @@ toTypedAlts :: [Alt TCPatn TCExpr] -> [Alt TypedPatn TypedExpr]
 toTypedAlts = fmap (ffmap (fmap toDepType) . fmap toTypedExpr)
 
 toDepType :: TCType -> DepType
-toDepType (T x) = DT (fffmap (fmap toRawType . toTCExpr) $ ffmap toDLExpr $ fmap toDepType x)
+toDepType (T x) = DT (fffmap (fmap toRawType . toTCExpr) $ fmap toDepType x)
 toDepType _ = __impossible "toDepType: unification variable found"
 
 toRawType :: TCType -> RawType
@@ -511,18 +514,19 @@ toRawType (T x) = RT (fffmap (toRawExpr' . toTCExpr) $ ffmap toDLExpr $ fmap toR
 toRawType _ = __impossible "toRawType: unification variable found"
 
 toRawType' :: DepType -> RawType
-toRawType' (DT t) = RT (fffmap toRawExpr'' $ fmap toRawType' t)
+toRawType' (DT t) = RT (fffmap toRawExpr'' $ ffmap toDLExpr $ fmap toRawType' t)
 
 -- This function although is partial, it should be ok, as we statically know that 
 -- we won't run into those undefined cases. / zilinc
 rawToDepType :: RawType -> DepType
 rawToDepType (RT t) = DT $ go t
-  where go :: Type RawExpr DataLayoutExpr RawType -> Type RawTypedExpr DataLayoutExpr DepType
+  where go :: Type RawExpr DataLayoutExpr RawType -> Type RawTypedExpr TCDataLayout DepType
         go t = let f = rawToDepType
+                   g = toTCDL
                 in case t of
-                     TCon tn ts s    -> TCon tn (fmap f ts) s
+                     TCon tn ts s    -> TCon tn (fmap f ts) (fmap (fmap g) s)
                      TVar v b u      -> TVar v b u
-                     TRecord rp fs s -> TRecord rp (fmap (second $ first f) fs) s
+                     TRecord rp fs s -> TRecord rp (fmap (second $ first f) fs) (fmap (fmap g) s)
                      TVariant alts   -> TVariant (fmap (first $ fmap f) alts)
                      TTuple ts       -> TTuple $ fmap f ts
                      TUnit           -> TUnit
@@ -530,8 +534,8 @@ rawToDepType (RT t) = DT $ go t
                      TBang t         -> TBang $ f t
                      TTake mfs t     -> TTake mfs $ f t
                      TPut mfs t      -> TPut mfs $ f t
-                     TLayout l t     -> TLayout l $ f t
-                     _               -> __impossible $ "rawToDepType: we don't allow higher-order refinement types"
+                     TLayout l t     -> TLayout (g l) $ f t
+                     _               -> __impossible "rawToDepType: we don't allow higher-order refinement types"
 
 toRawTypedExpr :: TypedExpr -> RawTypedExpr
 toRawTypedExpr (TE t e l) = TE (toRawType' t) (fffffmap toRawType' $ ffffmap (fmap toRawType') $ fffmap (fmap toRawType') $ fmap (fmap toRawType') e) l
@@ -869,8 +873,8 @@ isTypeLayoutExprCompatible env (T (TArray t _ Unboxed _)) (TLArray l _) = isType
 isTypeLayoutExprCompatible env t (TLOffset l _) = isTypeLayoutExprCompatible env t l
 isTypeLayoutExprCompatible env t (TLRepRef n s) =
   case M.lookup n env of
-    Just (v, l, _) -> isTypeLayoutExprCompatible env t (substTCDataLayout (zip v s) (toTCDL l))
-    Nothing        -> False  -- TODO(dargent): this really shoud be an exceptional state
+    Just (v, l) -> isTypeLayoutExprCompatible env t (substTCDataLayout (zip v s) l)
+    Nothing     -> False  -- TODO(dargent): this really shoud be an exceptional state
 isTypeLayoutExprCompatible _ t (TLVar n) = True -- FIXME
 isTypeLayoutExprCompatible _ t l = trace ("t = " ++ show t ++ "\nl = " ++ show l) False
 

--- a/cogent/src/Cogent/TypeCheck/Generator.hs
+++ b/cogent/src/Cogent/TypeCheck/Generator.hs
@@ -266,7 +266,7 @@ validateLayouts :: Traversable t => t DataLayoutExpr -> CG (Constraint, t TCData
 validateLayouts = fmapFoldM validateLayout
 
 cgSubstedType :: TCType -> CG Constraint
-cgSubstedType (T (TLayout l t)) = cgDataLayout' l
+cgSubstedType (T (TLayout l t)) = cgDataLayout l
 cgSubstedType (T t) = foldMapM cgSubstedType t
 cgSubstedType (U x) = pure Sat
 cgSubstedType (V x) = foldMapM cgSubstedType x
@@ -277,13 +277,13 @@ cgSubstedType (A t l s tkns) = (<>) <$> cgSubstedType t <*> cgSubstedSigil s
 cgSubstedType (Synonym n ts) = foldMapM cgSubstedType ts
 
 cgSubstedSigil :: Either (Sigil (Maybe TCDataLayout)) Int -> CG Constraint
-cgSubstedSigil (Left (Boxed _ (Just l))) = cgDataLayout' l
+cgSubstedSigil (Left (Boxed _ (Just l))) = cgDataLayout l
 cgSubstedSigil _ = pure Sat
 
-cgDataLayout' :: TCDataLayout -> CG Constraint
-cgDataLayout' l@(TLVariant e fs) = return $ WellformedLayout l
-cgDataLayout' l@(TLRecord fs) = return $ WellformedLayout l
-cgDataLayout' l = return Sat  -- TODO verify?
+cgDataLayout :: TCDataLayout -> CG Constraint
+cgDataLayout l@(TLVariant e fs) = return $ WellformedLayout l
+cgDataLayout l@(TLRecord fs) = return $ WellformedLayout l
+cgDataLayout l = return Sat  -- TODO how to deal with TLRepRef?
 
 -- -----------------------------------------------------------------------------
 -- Term-level constraints

--- a/cogent/src/Cogent/TypeCheck/Post.hs
+++ b/cogent/src/Cogent/TypeCheck/Post.hs
@@ -14,7 +14,7 @@
 {-# OPTIONS_GHC -fno-warn-unused-do-bind #-}
 
 module Cogent.TypeCheck.Post (
-  postA, postE, postT
+  postA, postE, postT, postL
 ) where
 
 import Cogent.Common.Syntax
@@ -68,6 +68,11 @@ postA as = do
   traceTc "post" (text "alternative" <+> pretty as)
   toTypedAlts <$> normaliseA d as
 
+postL :: TCDataLayout -> Post DataLayoutExpr
+postL l = do
+  layouts <- lift . lift $ use knownDataLayouts
+  traceTc "post" (text "layout" <+> pretty l)
+  return . toDLExpr $ normaliseLayout layouts l
 
 normaliseA :: TypeDict -> [Alt TCPatn TCExpr] -> Post [Alt TCPatn TCExpr]
 normaliseA d as = traverse (traverse (normaliseE d) >=> ttraverse (normaliseP d)) as
@@ -92,7 +97,7 @@ normaliseE d te@(TE t e l) = do
 normaliseL :: TCDataLayout -> Post TCDataLayout
 normaliseL l = do
   layouts <- lift . lift $ use knownDataLayouts
-  return $ normaliseTCDataLayout layouts l
+  return $ normaliseLayout layouts l
 
 normaliseP :: TypeDict -> TCPatn -> Post TCPatn
 normaliseP d tp@(TP p l) = do

--- a/cogent/src/Cogent/TypeCheck/Solver/Normalise.hs
+++ b/cogent/src/Cogent/TypeCheck/Solver/Normalise.hs
@@ -154,6 +154,7 @@ normL l = do
     TLRecord fs -> TLRecord <$> mapM (third3M normL) fs
     TLVariant l fs -> TLVariant <$> normL l <*> mapM (fourth4M normL) fs
     TLOffset l n -> TLOffset <$> normL l <*> pure n
+    TLAfter l f -> TLAfter <$> normL l <*> pure f
     _ -> pure l
   fromMaybe step <$> runMaybeT (runRewriteT (untilFixedPoint $ debug "Normalise Layout" printPretty normaliseRWL) step)
 

--- a/cogent/src/Cogent/TypeCheck/Solver/Normalise.hs
+++ b/cogent/src/Cogent/TypeCheck/Solver/Normalise.hs
@@ -135,12 +135,13 @@ whnf input = do
         _                -> pure input
     fromMaybe step <$> runMaybeT (runRewriteT (untilFixedPoint $ debug "Normalise Type" printPretty normaliseRWT) step)
 
+-- TODO: TLAfter
 normaliseRWL :: RewriteT TcSolvM TCDataLayout
 normaliseRWL = rewrite' $ \case
   TLRepRef n s -> do
     ls <- view knownDataLayouts
     case M.lookup n ls of
-      Just (vars, expr, _) -> pure $ normaliseTCDataLayout ls (substTCDataLayout (zip vars s) (toTCDL expr))
+      Just (vars, expr) -> MaybeT $ Just <$> normL (substTCDataLayout (zip vars s) expr)
       _ -> __impossible "normaliseRWL: missing layout synonym"
   _ -> empty
 

--- a/cogent/src/Cogent/TypeCheck/Solver/Simplify.hs
+++ b/cogent/src/Cogent/TypeCheck/Solver/Simplify.hs
@@ -372,6 +372,10 @@ simplify ks ts = Rewrite.pickOne' $ onGoal $ \case
   UnboxedNotRecursive (R None _ (Left Unboxed))     -> hoistMaybe $ Just []
   UnboxedNotRecursive (R _ _    (Left (Boxed _ _))) -> hoistMaybe $ Just []
 
+  -- TODO TODO TODO
+  Wellformed l -> hoistMaybe $ Just []
+  -- TODO TODO TODO
+
   t -> hoistMaybe $ Nothing
 
 -- | Returns 'True' iff the given argument type is not subject to subtyping. That is, if @a :\< b@

--- a/cogent/src/Cogent/TypeCheck/Solver/Simplify.hs
+++ b/cogent/src/Cogent/TypeCheck/Solver/Simplify.hs
@@ -40,6 +40,7 @@ import           Control.Monad
 import           Control.Monad.IO.Class (liftIO)
 import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans.Class (lift)
+import qualified Data.Graph.Wrapper as G
 import           Data.List as L (elemIndex, isSubsequenceOf, null, (\\))
 import qualified Data.Map as M
 import           Data.Maybe
@@ -372,9 +373,25 @@ simplify ks ts = Rewrite.pickOne' $ onGoal $ \case
   UnboxedNotRecursive (R None _ (Left Unboxed))     -> hoistMaybe $ Just []
   UnboxedNotRecursive (R _ _    (Left (Boxed _ _))) -> hoistMaybe $ Just []
 
-  -- TODO TODO TODO
-  Wellformed l -> hoistMaybe $ Just []
-  -- TODO TODO TODO
+  -- TODO: check for overlapping & tag expression & tag values
+  WellformedLayout (TLRecord fs) ->
+    do let dep = fmap (\(a,_,c) -> case c of TLAfter e f -> (a,(),[f]); _ -> (a,(),[])) fs
+       let grp = G.fromListLenient dep
+       let cyc = [x | x@(G.CyclicSCC _) <- G.stronglyConnectedComponents grp]
+       let miv = [a | x@(a,_,_) <- dep, G.indegree grp a >= 2]
+       case (null cyc, null miv) of
+         (True, True) -> hoistMaybe $ Just []
+         (True, False) -> unsat . DataLayoutError $ overlappingFields [a | (a,_,c@[f])<- dep, [f] == [head miv]]
+         (False, _) -> unsat . DataLayoutError $ cyclicFieldDependency (head cyc)
+  WellformedLayout (TLVariant e fs) ->
+    do let dep = fmap (\(a,_,_,d) -> case d of TLAfter e f -> (a,(),[f]); _ -> (a,(),[])) fs
+       let grp = G.fromListLenient dep
+       let cyc = [x | x@(G.CyclicSCC _) <- G.stronglyConnectedComponents grp]
+       let miv = [a | x@(a,_,_) <- dep, G.indegree grp a >= 2]
+       case (null cyc, null miv) of
+         (True, True) -> hoistMaybe $ Just []
+         (True, False) -> unsat . DataLayoutError $ overlappingFields [a | (a,_,c@[f]) <- dep, [f] == [head miv]]
+         (False, _) -> unsat . DataLayoutError $ cyclicFieldDependency (head cyc)
 
   t -> hoistMaybe $ Nothing
 

--- a/cogent/src/Cogent/TypeCheck/Solver/Simplify.hs
+++ b/cogent/src/Cogent/TypeCheck/Solver/Simplify.hs
@@ -38,9 +38,9 @@ import           Cogent.Util (hoistMaybe)
 import           Control.Applicative
 import           Control.Monad
 import           Control.Monad.IO.Class (liftIO)
+import           Control.Monad.Trans.Except (runExcept)
 import           Control.Monad.Trans.Maybe
 import           Control.Monad.Trans.Class (lift)
-import qualified Data.Graph.Wrapper as G
 import           Data.List as L (elemIndex, isSubsequenceOf, null, (\\))
 import qualified Data.Map as M
 import           Data.Maybe
@@ -182,6 +182,7 @@ simplify ks ts = Rewrite.pickOne' $ onGoal $ \case
 #endif
 
   TLOffset e _   :~ tau -> hoistMaybe $ Just [e :~ tau]
+  TLAfter  e _   :~ tau -> hoistMaybe $ Just [e :~ tau]
 
   TLPrim n       :~ tau
     | isPrimType tau
@@ -211,6 +212,7 @@ simplify ks ts = Rewrite.pickOne' $ onGoal $ \case
   TLVar v1         :~< TLVar v2      | v1 == v2 -> hoistMaybe $ Just []
   TLPrim n1        :~< TLPrim n2     | n1 <= n2 -> hoistMaybe $ Just []
   TLOffset e1 _    :~< TLOffset e2 _ -> hoistMaybe $ Just [e1 :~< e2]
+  TLAfter e1 _     :~< TLAfter e2 _  -> hoistMaybe $ Just [e1 :~< e2]
 
   TLRecord fs1     :~< TLRecord fs2
     | r1 <- LRow.fromList $ map (\(a,b,c) -> (a,c,())) fs1
@@ -373,25 +375,12 @@ simplify ks ts = Rewrite.pickOne' $ onGoal $ \case
   UnboxedNotRecursive (R None _ (Left Unboxed))     -> hoistMaybe $ Just []
   UnboxedNotRecursive (R _ _    (Left (Boxed _ _))) -> hoistMaybe $ Just []
 
-  -- TODO: check for overlapping & tag expression & tag values
-  WellformedLayout (TLRecord fs) ->
-    do let dep = fmap (\(a,_,c) -> case c of TLAfter e f -> (a,(),[f]); _ -> (a,(),[])) fs
-       let grp = G.fromListLenient dep
-       let cyc = [x | x@(G.CyclicSCC _) <- G.stronglyConnectedComponents grp]
-       let miv = [a | x@(a,_,_) <- dep, G.indegree grp a >= 2]
-       case (null cyc, null miv) of
-         (True, True) -> hoistMaybe $ Just []
-         (True, False) -> unsat . DataLayoutError $ overlappingFields [a | (a,_,c@[f])<- dep, [f] == [head miv]]
-         (False, _) -> unsat . DataLayoutError $ cyclicFieldDependency (head cyc)
-  WellformedLayout (TLVariant e fs) ->
-    do let dep = fmap (\(a,_,_,d) -> case d of TLAfter e f -> (a,(),[f]); _ -> (a,(),[])) fs
-       let grp = G.fromListLenient dep
-       let cyc = [x | x@(G.CyclicSCC _) <- G.stronglyConnectedComponents grp]
-       let miv = [a | x@(a,_,_) <- dep, G.indegree grp a >= 2]
-       case (null cyc, null miv) of
-         (True, True) -> hoistMaybe $ Just []
-         (True, False) -> unsat . DataLayoutError $ overlappingFields [a | (a,_,c@[f]) <- dep, [f] == [head miv]]
-         (False, _) -> unsat . DataLayoutError $ cyclicFieldDependency (head cyc)
+  WellformedLayout l -> do
+    guard (null (unifLVars l))
+    guard (null (repRefTL l))
+    case runExcept $ checkAlloc l of
+      Left (e:_) -> unsat $ DataLayoutError e
+      Right r -> hoistMaybe $ Just []
 
   t -> hoistMaybe $ Nothing
 

--- a/cogent/src/Cogent/TypeCheck/Subst.hs
+++ b/cogent/src/Cogent/TypeCheck/Subst.hs
@@ -171,6 +171,7 @@ applyL s (TLVariant e fs) = TLVariant (applyL s e) $
 applyL s (TLArray e p) = TLArray (applyL s e) p
 #endif
 applyL s (TLOffset e n) = TLOffset (applyL s e) n
+applyL s (TLAfter e f) = TLAfter (applyL s e) f
 applyL s l = l
 
 applyC :: Subst -> Constraint -> Constraint


### PR DESCRIPTION
now we should be able to write `record { f1: 1B, f2: 1B at 1B }`  as `record { f1: 1B, f2: 1B after 1B }`