### PR TITLE
Shallow embedding of ArrayPut and ArrayTake

### DIFF
--- a/cogent/isa/shallow/ShallowUtil.thy
+++ b/cogent/isa/shallow/ShallowUtil.thy
@@ -16,6 +16,9 @@ theory ShallowUtil
     "Cogent.Util"
 begin
 
+definition nth' :: "nat \<Rightarrow> 'a list \<Rightarrow> 'a"
+  where "nth' n l = l ! n"
+
 definition
   fun_app :: "('a \<Rightarrow> 'b) \<Rightarrow> 'a \<Rightarrow> 'b" (infixr "$" 10)
 where


### PR DESCRIPTION
This PR implements the shallow embedding of ArrayPut, which is enough to compile the shallow embedding the led driver..

This PR also implements the shallow embedding of ArrayTake, but it couldn't be tested, as it seems the compilation of ArrayTake is not yet implemented (yielding TODO fvIP: PArrayTake unimplemented)