### PR TITLE
Fix and improve shallow representation

### DIFF
--- a/cogent/src/Cogent/Isabelle/Shallow.hs
+++ b/cogent/src/Cogent/Isabelle/Shallow.hs
@@ -371,6 +371,9 @@ sanitizeType (TRecord rp ts _) = TRecord rp (map (\(tn, (t,_)) -> (tn, (sanitize
 sanitizeType (TCon tn ts _) = TCon tn (map sanitizeType ts) Unboxed
 sanitizeType (TFun ti to) = TFun (sanitizeType ti) (sanitizeType to)
 sanitizeType (TProduct t t') = TProduct (sanitizeType t) (sanitizeType t')
+#ifdef BUILTIN_ARRAYS
+sanitizeType (TArray t _ _ _) = TArray (sanitizeType t) (LSLit "") Unboxed Nothing
+#endif
 sanitizeType t = t
 
 -- | Produce a hash for a record or variant type. Only the structure of the type matters;
@@ -378,6 +381,9 @@ sanitizeType t = t
 hashType :: (Show b) => CC.Type t b -> String
 hashType (TSum ts)      = show (sanitizeType $ TSum ts)
 hashType (TRecord rp ts s) = show (sanitizeType $ TRecord rp ts s)
+#ifdef BUILTIN_ARRAYS
+hashType (TArray t sz s tk) = show (sanitizeType $ TArray t sz s tk)
+#endif
 hashType _              = error "hashType: should only pass Variant and Record types"
 
 -- | A subscript @T@ will be added when generating type synonyms.

--- a/cogent/src/Cogent/Isabelle/Shallow.hs
+++ b/cogent/src/Cogent/Isabelle/Shallow.hs
@@ -201,7 +201,11 @@ findTypeSyn t = findType t >>= \(TCon nm _ _) -> pure nm
 
 shallowExpr :: (Show b) => TypedExpr t v VarName b -> SG Term
 shallowExpr (TE _ (Variable (_,v))) = pure $ mkId (snm v)
-shallowExpr (TE _ (Fun fn ts ls _)) = pure $ mkId $ snm $ unCoreFunName fn  -- only prints the fun name
+shallowExpr (TE t (Fun fn ts ls _)) = 
+    if null ts 
+       then pure $ mkId $ snm $ unCoreFunName fn
+       else -- for polymorphic functions add its type
+            TermWithType (mkId $ snm $ unCoreFunName fn) <$> shallowType t
 shallowExpr (TE _ (Op opr es)) = shallowPrimOp <$> pure opr <*> (mapM shallowExpr es)
 shallowExpr (TE _ (App f arg)) = mkApp <$> shallowExpr f <*> (mapM shallowExpr [arg])
 shallowExpr (TE t (Con cn e _))  = do


### PR DESCRIPTION
This pull request provides three features for the shallow embedding:
1) fix of issue #382 by adding a type specification to all invocations of polymorphic functions.
2) improve reuse of monomorphic type synonyms: Extend it to types containing builtin array types.
3) Initial partial support for reuse of polymorphic type synonyms. This is not perfect, but it works in many cases. 

Features 2 and 3 only make the shallow embedding better readable for humans.
In all three cases no proofs should be affected.