### PR TITLE
disallow oversized tags for variants

### DIFF
--- a/cogent/src/Cogent/PrettyPrint.hs
+++ b/cogent/src/Cogent/PrettyPrint.hs
@@ -982,8 +982,10 @@ instance Pretty DataLayoutTcError where
      =  err "Undeclared data layout" <+> reprname r <$$> pretty ctx
 
   pretty (BadDataLayout l p) = err "Bad data layout" <+> pretty l
-  pretty (TagNotSingleBlock ctx) 
-     = err "Variant tag must be a single block of bits" <$$> pretty ctx
+  pretty (TagSizeTooLarge ctx) =
+    err "Variant tag allocated more bits than necessary" <$$> pretty ctx
+  pretty (TagNotSingleBlock ctx) =
+    err "Variant tag must be a single block of bits" <$$> pretty ctx
   pretty (SameTagValues context name1 name2 value) =
     err "Alternatives" <+> tagname name1 <+> err "and" <+> tagname name2 <+> err "of same variant cannot have the same tag value" <+> literal (pretty value) <$$>
     indent (pretty context)

--- a/cogent/tests-quickcheck/CogentTests/Dargent/Core.hs
+++ b/cogent/tests-quickcheck/CogentTests/Dargent/Core.hs
@@ -124,8 +124,15 @@ genSumLayout maxBitIndex maxSize alloc =
       -> Allocation -- existing allocation
       -> Gen (Map TagName (Size, DataLayout' BitRange), Allocation)
 
-    genAlts 0 _ _ alloc          = return (M.empty, alloc)
     genAlts _ m n alloc | m == n = return (M.empty, alloc)
+
+    genAlts 0 tagValue maxTagValue alloc = do
+      sourcePos <- arbitrary
+      (remainingAlts, remainingAlloc) <- genAlts 0 (tagValue + 1) maxTagValue alloc
+      let altName = show tagValue
+      (altLayout, altAlloc) <- genDataLayout' maxBitIndex 0 alloc
+      let altAlloc' = fmap (InAlt altName sourcePos) altAlloc
+      return (M.insert altName (tagValue, altLayout) remainingAlts, altAlloc' \/ remainingAlloc)
 
     genAlts maxSize tagValue maxTagValue alloc = do
       sourcePos <- arbitrary


### PR DESCRIPTION
tag size is determined by the maximum tag value among alternatives

for variants without any alternative, tag of size 1bit is allowed, this behaviour might be discussed later