### PR TITLE
fix #377: field names in uval (and expr, repr)

### DIFF
--- a/c-refinement/CogentHigherOrder.thy
+++ b/c-refinement/CogentHigherOrder.thy
@@ -89,7 +89,7 @@ fun funcall_sem :: "'f InValue env \<Rightarrow> 'f expr \<Rightarrow> ('f FunCa
 | "funcall_sem \<gamma> (Con _ tag x) =
      (let (calls, ptrs) = funcall_sem \<gamma> x
       in (calls, map ((#) (InSum tag)) ptrs))"
-| "funcall_sem \<gamma> (Struct tys xs) =
+| "funcall_sem \<gamma> (Struct ns tys xs) =
      (let (callss, ptrss) = unzip (map (funcall_sem \<gamma>) xs)
       in (concat callss, concat (map (\<lambda>(n, v). map ((#) (InRecord n)) v) (enumerate 0 ptrss))))"
 | "funcall_sem \<gamma> (Member x f) =

--- a/c-refinement/Cogent_Corres.thy
+++ b/c-refinement/Cogent_Corres.thy
@@ -491,8 +491,8 @@ qed (simp add: u_sem_all_empty)
 lemma corres_struct:
 assumes
  "\<And>\<sigma> s. (\<sigma>, s) \<in> srel \<Longrightarrow>
-  val_rel (URecord (zip (map (nth \<gamma>) xs) (map type_repr ts))) p"
-shows "corres srel (Struct ts (map Var xs)) (gets (\<lambda>_. p)) \<xi> \<gamma> \<Xi> \<Gamma> \<sigma> s"
+  val_rel (URecord (zip (map (nth \<gamma>) xs) (zip ns (map type_repr ts)))) p"
+shows "corres srel (Struct ns ts (map Var xs)) (gets (\<lambda>_. p)) \<xi> \<gamma> \<Xi> \<Gamma> \<sigma> s"
   by (fastforce intro: u_sem_struct u_sem_all_var simp: assms corres_def snd_return in_return)
 
 lemma corres_con:
@@ -701,8 +701,8 @@ lemma corres_take_boxed':
   (do _ \<leftarrow> guard (\<lambda>s. is_valid s x'); z \<leftarrow> gets f'; e' z od)
   \<xi> \<gamma> \<Xi> \<Gamma> \<sigma> s"
 proof -
-  have HELP: "\<And>tag t b. typ ! f = (tag, t, b) \<Longrightarrow> map (type_repr \<circ> fst \<circ> snd) typ = map (type_repr \<circ> fst \<circ> snd) (typ[f := (tag, t, Present)])"
-    by (simp add: map_update, metis (mono_tags, lifting) comp_def list_update_id map_update prod_injects(1))
+  have HELP: "\<And>tag t b. typ ! f = (tag, t, b) \<Longrightarrow> map (\<lambda> (n,t,_). (n, type_repr t)) typ = map (\<lambda> (n,t,_). (n, type_repr t)) (typ[f := (tag, t, Present)])"
+    by (simp add: map_update, metis (mono_tags, lifting)  old.prod.case list_update_id map_update prod_injects(1))
   show ?thesis
     apply (clarsimp simp: corres_def in_monad snd_bind snd_gets snd_state_assert)
     apply (rename_tac r w)
@@ -965,7 +965,7 @@ proof (clarsimp simp: corres_def in_monad snd_bind snd_modify snd_state_assert, 
 
   obtain fs w13
     where uval_typing1_elim_lemmas:
-      "repr = RRecord (map (\<lambda>(n, t, b). type_repr t) typ)"
+      "repr = RRecord (map (\<lambda>(n, t, b). (n, type_repr t)) typ)"
       "w13p = insert p w13"
       "\<Xi>, \<sigma> \<turnstile>* fs :ur typ \<langle>r13', w13\<rangle>"
       "\<sigma> p = Some (URecord fs)"
@@ -991,7 +991,7 @@ proof (clarsimp simp: corres_def in_monad snd_bind snd_modify snd_state_assert, 
         "w1p' = insert p w1'"
         "\<Xi>, \<sigma>(p \<mapsto> URecord (fs[f := (\<gamma> ! e, snd (fs ! f))])) \<turnstile>* (fs[f := (\<gamma> ! e, snd (fs ! f))]) :ur typ[f := (fst (typ ! f), fst (snd (typ ! f)), Present)] \<langle>r1', w1'\<rangle>"
         "distinct (map fst (typ[f := (fst (typ ! f), fst (snd (typ ! f)), Present)]))"
-        "repr = RRecord (map (type_repr \<circ> fst \<circ> snd) (typ[f := (fst (typ ! f), fst (snd (typ ! f)), Present)]))"
+        "repr = RRecord (map (\<lambda> (n,t,_). (n, type_repr t)) (typ[f := (fst (typ ! f), fst (snd (typ ! f)), Present)]))"
         "sgl = Boxed Writable ptrl"
         "p \<notin> w1'"
         "p \<notin> r1'"
@@ -1008,12 +1008,12 @@ proof (clarsimp simp: corres_def in_monad snd_bind snd_modify snd_state_assert, 
     by fastforce
 
   then have "\<Xi>, \<sigma>(p \<mapsto> URecord (fs[f := (\<gamma> ! e, snd (fs ! f))])) \<turnstile>
-              UPtr p (RRecord (map (type_repr \<circ> fst \<circ> snd) (typ[f := (fst (typ ! f), fst (snd (typ ! f)), Present)]))) :u
+              UPtr p (RRecord (map (\<lambda> (n,t,_). (n, type_repr t)) (typ[f := (fst (typ ! f), fst (snd (typ ! f)), Present)]))) :u
               TRecord typ (Boxed Writable ptrl)
             \<langle>r1'', insert p w1''\<rangle>"
     using rec_elim1_lemmas taken_field1_lemmas
   proof (intro u_t_p_rec_w')
-    show "RRecord (map (type_repr \<circ> fst \<circ> snd) (typ[f := (fst (typ ! f), fst (snd (typ ! f)), Present)])) = RRecord (map (type_repr \<circ> fst \<circ> snd) typ)"
+    show "RRecord (map (\<lambda> (n,t,_). (n, type_repr t)) (typ[f := (fst (typ ! f), fst (snd (typ ! f)), Present)])) = RRecord (map (\<lambda> (n,t,_). (n, type_repr t)) typ)"
       by (clarsimp, metis rec_elim1_lemmas(2) taken_field1_lemmas(3) type_repr_uval_repr(2))
   next
     show "distinct (map fst typ)"

--- a/c-refinement/Type_Relation_Generation.thy
+++ b/c-refinement/Type_Relation_Generation.thy
@@ -25,12 +25,18 @@ fun mk_rhs_of_type_rel_rec _ (field_info:HeapLiftBase.field_info list) =
  * We assume that there are (length field_info) bound variables
  * corresponding to the type repr for each field. *)
  let
+  val _ = @{print} field_info
   val num_fields = List.length field_info;
 
   (* mk_hd_conjct makes e.g. @{term "ty = TRecord [(''a'', a), (''b'', b)]"} in the body.*)
   val mk_hd_conjct =
    let
-    val ml_list_for_TRecord = map_index (fn (n, _) => Bound (num_fields - n - 1)) field_info;
+    fun make_name s = if String.isSuffix "_C" s then 
+                           (* remove the _C suffix *)
+                           String.substring (s, 0, String.size s - 2) 
+                      else error ("mk_rhs_of_type_rel_rec: not a C field " ^ s)
+    val ml_list_for_TRecord = map_index (fn (n, i ) =>
+     encode_isa_pair (HOLogic.mk_string (# name i |> make_name), Bound (num_fields - n - 1))) field_info;
     val RRecord = Const (@{const_name RRecord}, dummyT) $ mk_isa_list ml_list_for_TRecord
    in
     HOLogic.mk_eq (Free ("ty", dummyT), RRecord)

--- a/cogent/isa/CogentHelper.thy
+++ b/cogent/isa/CogentHelper.thy
@@ -51,7 +51,7 @@ lemma typing_struct': "\<lbrakk> \<Xi>, K, \<Gamma> \<turnstile>* es : ts
                        ; distinct ns
                        ; map (fst \<circ> snd) ts' = ts
                        ; list_all (\<lambda>p. snd (snd p) = Present) ts'
-                       \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> Struct ts es : TRecord ts' Unboxed"
+                       \<rbrakk> \<Longrightarrow> \<Xi>, K, \<Gamma> \<turnstile> Struct ns ts es : TRecord ts' Unboxed"
   by (force intro: typing_struct simp add: zip_eq_conv_sym replicate_eq_map_conv_nth list_all_length)
 
 lemma typing_afun': "\<lbrakk> \<Xi> f = (ks, t, u)

--- a/cogent/isa/Mono.thy
+++ b/cogent/isa/Mono.thy
@@ -30,7 +30,7 @@ where
 | "rename_expr rename (Prim p es)       = Prim p (map (rename_expr rename) es)"
 | "rename_expr rename (App a b)         = App (rename_expr rename a) (rename_expr rename b)"
 | "rename_expr rename (Con as t e)      = Con as t (rename_expr rename e)"
-| "rename_expr rename (Struct ts vs)    = Struct ts (map (rename_expr rename) vs)"
+| "rename_expr rename (Struct ns ts vs) = Struct ns ts (map (rename_expr rename) vs)"
 | "rename_expr rename (Member v f)      = Member (rename_expr rename v) f"
 | "rename_expr rename (Unit)            = Unit"
 | "rename_expr rename (Cast t e)        = Cast t (rename_expr rename e)"
@@ -147,7 +147,7 @@ next
     apply (case_tac vval, simp_all)
     by (fastforce intro!: v_sem_v_sem_all.v_sem_esac)
 next
-  case (v_sem_struct \<xi> xs vs ts \<gamma> e \<tau> \<Gamma>) then show ?case
+  case (v_sem_struct \<xi> xs vs ts \<gamma> ns e \<tau> \<Gamma>) then show ?case
     by (cases e) (fastforce intro: v_sem_v_sem_all.v_sem_struct)+
 next
   case (v_sem_if \<xi> rb b e1 e2 v \<gamma> e \<tau> \<Gamma>)

--- a/cogent/isa/TypeTrackingSemantics.thy
+++ b/cogent/isa/TypeTrackingSemantics.thy
@@ -337,7 +337,7 @@ next
         "w1' = insert p w1''"
         "\<Xi>, \<sigma>'' \<turnstile>* fs :ur ts \<langle>r1', w1''\<rangle>"
         "\<sigma>'' p = Some (URecord fs)"
-        "r' = RRecord (map (type_repr \<circ> fst \<circ> snd) ts)"
+        "r' = RRecord (map (\<lambda> (n,t,_). (n, type_repr t)) ts)"
         "distinct (map fst ts)"
         "s = Boxed Writable ptrl"
         "p \<notin> w1''"
@@ -388,9 +388,9 @@ next
         proof (simp only: snd_t\<Gamma>4_is append_Cons append.left_neutral, intro matches_ptrs_some[OF _ matches_ptrs_some])
           have "\<Xi>, \<sigma>'' \<turnstile>* fs :ur ts[f := (n, t, taken)] \<langle>r1a, w1a\<rangle>"
             by (simp add: ut_fs_taken_f Taken)
-          moreover have "r' = RRecord (map (type_repr \<circ> fst \<circ> snd) (ts[f := (n, t, taken)]))"
-              using Taken type_repr_uval_repr uptr_p_elim_lemmas ut_fs_taken_f
-              by (metis (full_types))
+          moreover have "r' = RRecord (map (\<lambda> (n,t,_). (n, type_repr t)) (ts[f := (n, t, taken)]))"
+            using Taken type_repr_uval_repr uptr_p_elim_lemmas ut_fs_taken_f            
+            by metis
           ultimately show "\<Xi>, \<sigma>'' \<turnstile> UPtr p r' :u TRecord (ts[f := (n, t, taken)]) s \<langle>r1a, insert p w1a\<rangle>"
             using uptr_p_elim_lemmas ut_fs_taken_f r1'_is w1''_is
             by (simp, intro u_t_p_rec_w';

--- a/cogent/isa/ValueSemantics.thy
+++ b/cogent/isa/ValueSemantics.thy
@@ -117,7 +117,7 @@ where
                    \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> If x t e \<Down> r"
 
 | v_sem_struct  : "\<lbrakk> \<xi> , \<gamma> \<turnstile>* xs \<Down> vs
-                   \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> Struct ts xs \<Down> VRecord vs"
+                   \<rbrakk> \<Longrightarrow> \<xi> , \<gamma> \<turnstile> Struct ns ts xs \<Down> VRecord vs"
 
 | v_sem_take    : "\<lbrakk> \<xi> , \<gamma> \<turnstile> x \<Down> VRecord fs
                    ; \<xi> , (fs ! f # VRecord fs # \<gamma>) \<turnstile> e \<Down> e'
@@ -1145,7 +1145,7 @@ function monoexpr :: "'f expr \<Rightarrow> ('f \<times> type list) expr" where
 | "monoexpr (Prim p es)       = Prim p (map (monoexpr) es)"
 | "monoexpr (App a b)         = App (monoexpr a) (monoexpr b)"
 | "monoexpr (Con as t e)      = Con as t (monoexpr e)"
-| "monoexpr (Struct ts vs)    = Struct ts (map (monoexpr) vs)"
+| "monoexpr (Struct ns ts vs)    = Struct ns ts (map (monoexpr) vs)"
 | "monoexpr (Member v f)      = Member (monoexpr v) f"
 | "monoexpr (Unit)            = Unit"
 | "monoexpr (Cast t e)        = Cast t (monoexpr e)"

--- a/cogent/isa/shallow/Shallow.thy
+++ b/cogent/isa/shallow/Shallow.thy
@@ -32,7 +32,7 @@ inductive_cases v_sem_splitE: "\<xi> , \<gamma> \<turnstile> Split x e \<Down> e
 inductive_cases v_sem_takeE: "\<xi> , \<gamma> \<turnstile> Take x f e \<Down> e'"
 inductive_cases v_sem_putE: "\<xi> , \<gamma> \<turnstile> Put x f e \<Down> e'"
 inductive_cases v_sem_castE: "\<xi> , \<gamma> \<turnstile> Cast \<tau> e \<Down> e'"
-inductive_cases v_sem_structE: "\<xi> , \<gamma> \<turnstile> Struct ts xs \<Down> e'"
+inductive_cases v_sem_structE: "\<xi> , \<gamma> \<turnstile> Struct ns ts xs \<Down> e'"
 inductive_cases v_sem_AppE: "\<xi> , \<gamma> \<turnstile> App f v \<Down> e'"
 inductive_cases v_sem_allE: "\<xi> , \<gamma> \<turnstile>* es \<Down> es'"
 inductive_cases v_sem_all_NilE: "\<xi> , \<gamma> \<turnstile>* [] \<Down> es'"

--- a/cogent/src/Cogent/Isabelle/Shallow.hs
+++ b/cogent/src/Cogent/Isabelle/Shallow.hs
@@ -1019,7 +1019,7 @@ scorresStructLemma name fields = let
   assums = [ "scorres " ++ x ++ " " ++ y ++ " \\<gamma> \\<xi>"
            | (x, y) <- P.zip (varNames "s") (varNames "d") ]
   concl = "scorres (" ++ name ++ ".make " ++ unwords (varNames "s") ++ ") " ++
-          "(Struct ts [" ++ intercalate ", " (varNames "d") ++ "]) \\<gamma> \\<xi>"
+          "(Struct ns ts [" ++ intercalate ", " (varNames "d") ++ "]) \\<gamma> \\<xi>"
   prop = "\\<And>" ++ intercalate " " all_names ++ ".\n" ++ intercalate " \\<Longrightarrow>\n" (assums ++ [concl])
   method = Method "clarsimp" ["simp:", "scorres_def", "valRel_" ++ name, name ++ ".defs",
                               "elim!:", "v_sem_elims"]


### PR DESCRIPTION
Representations of types should be in one-to-one correspondance with
C types for the put lemmas to be right. Thus they should contain
the field names for records.