### PR TITLE
compiler proof: Fixed the uabsfuns declaration

### DIFF
--- a/cogent/examples/system-abstract-verif/Makefile
+++ b/cogent/examples/system-abstract-verif/Makefile
@@ -77,7 +77,8 @@ verification:
 		$(COGENT_FLAGS) \
 		--infer-c-funcs="$(PLAT_DIR)/$(ACFILES)" \
 		--proof-input-c=wrapper_pp_inferred.c \
-		--proof-name=$(NAME) \
+		--proof-name=$(NAME) 
+	cp "$(BUILD_DIR)/$(OUTPUT).table" "$(BUILD_DIR)/wrapper_pp_inferred.table"
 
 clean:
 	rm -rf $(BUILD_DIR)

--- a/cogent/src/Cogent/Isabelle/CorresProof.hs
+++ b/cogent/src/Cogent/Isabelle/CorresProof.hs
@@ -122,7 +122,7 @@ context thy cfile fns ent =
   hofHints cfile ++
   checkHofHints ++
   cogentMainTree thy ent ++
-  xiN ++
+  xiN thy ++
   changeType ++
   corresThm ++
   runProof ++
@@ -228,8 +228,8 @@ cogentMainTree thy ent =
   , "\\<close>"
   ]
 
-xiN :: [String]
-xiN =
+xiN :: String -> [String]
+xiN thy =
   [ "(* Define \\<xi>_n. *)"
   , "ML \\<open>"
   , "(* FIXME: actually merge trees for uabsfuns *)"
@@ -238,7 +238,13 @@ xiN =
   , "    CogentCallTree_data tr ="
   , "    (Symtab.dest Cogent_main_tree |> map snd |> map CogentCallTree_data |> maximum))"
   , "\\<close>"
-  , "local_setup \\<open> define_uabsfuns' deepest_tree \\<close>"
+  , ""
+  , "end (* of context *)"
+  , ""
+  , "setup \\<open> declare_uabsfuns deepest_tree \\<close>"
+  , ""
+  , "context " ++ thy ++ " begin"
+  , ""
   ]
 
 changeType :: [String]


### PR DESCRIPTION
This commit fixes the declaration of the uabsfuns, i.e. the xi_0 and
xi_1 terms in the corres theorems. These are now declared as Isabelle
constants, which users can overload later on whilst theorems using these
constants will still remain true.

One minor fix is fixing the make file for the system-abstract-verif
example. It now copies the typing table to a file that Isabelle expects
to exist.